### PR TITLE
Add installation via core.hooksPath and setup new templatedir when running in non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ There is also an option to run the install script for the repository in the curr
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --single
 ```
 
+You can change this setting later with the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, running the `git hooks config [set|reset] single` command, which affects how future updates are run, when started from the local repository.
+
 Lastly, you have the option to install the templates to, and use them from a centralized location. You can read more about the difference between this option and default one [here](#Templates-vs-global-hooks). For this, run the command below.
 
 ```shell
@@ -208,8 +210,6 @@ By default the script will install the hooks into `~/.githooks/templates/`, opti
 ```shell
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-hookspath /home/public/.githooks
 ```
-
-You can change this setting later with the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, running the `git hooks config [set|reset] single` command, which affects how future updates are run, when started from the local repository.
 
 It's possible to specify which template directory should be used, by passing the `--template-dir <dir>` paramter, where `<dir>` is the directory where you wish the templated be installed.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,33 @@
 
 A simple Shell script to support per-repository [Git hooks](https://git-scm.com/docs/githooks), checked into the actual repository that uses them.
 
-To make this work, it creates hook templates that are installed into the `.git/hooks` folders automatically on `git init` and `git clone`. When one of them executes, it will try to find matching files in the `.githooks` directory under the project root, and invoke them one-by-one.
-
 > Check out the [blog post](https://blog.viktoradam.net/2018/07/26/githooks-auto-install-hooks/) for the long read!
+
+## Templates vs global hooks
+
+This script can work in one of 2 ways:
+
+- Using the git template folder (default behaviour)
+- Using the git `core.hooksPath` variable (set by passing the `--use-hookspath` parameter to the install script)
+
+Read about the differences between these 2 approaches below
+
+In both cases, the script will make sure git finds the hook templates provided by this script.
+When one of them executes, it will try to find matching files in the `.githooks` directory under the project root, and invoke them one-by-one.
+
+### Template folder
+
+In this approach, the install script creates hook templates that are installed into the `.git/hooks` folders automatically on `git init` and `git clone`.
+
+This is the recommanded approach if you want to selectively control which repositories use these scripts. The install script offers to search for repositories to which it will install the hooks, and any new repositories you clone will have these hooks configured.
+
+### Central hooks location (core.hooksPath)
+
+In this approach, the install script installs the hook templates into a centralized location (`~/.githooks/templates/` by default) and sets the global `core.hooksPath` variable to that location. Git will then, for all relevant actions, check the `core.hooksPath` location, instead of the default `$(GIT_DIR)/hooks` location.
+
+This approach works more like a 'blanket' solution, where any repository (\*) will start using the hook templates, regardless of its location.
+
+**Note**(\*): It is possible to override the behaviour for a specific repository, by setting a local `core.hooksPath` variable with value `$(GIT_DIR)/hooks/`, which will revert git back to its default behaviour for that specific repository.
 
 ## Layout and options
 
@@ -79,7 +103,7 @@ The supported hooks are listed below. Refer to the [Git documentation](https://g
 
 ## Ignoring files
 
-The `.ignore` files allow excluding files from being treated as a hook script. They allow *glob* filename patterns, empty lines and comments, where the line starts with a `#` character. In the above example, one of the `.ignore` files should contain `*.md` to exclude the `pre-commit/docs.md` Markdown file. The `.githooks/.ignore` file applies to each of the hook directories, and should still define filename patterns, `*.txt` instead of `**/*.txt` for example. If there is a `.ignore` file both in the hook type folder and in `.githooks`, the files whose filename matches any pattern from either of those two files will be excluded. You can also manage `.ignore` files using the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, and running `git hooks ignore <pattern>`.
+The `.ignore` files allow excluding files from being treated as a hook script. They allow _glob_ filename patterns, empty lines and comments, where the line starts with a `#` character. In the above example, one of the `.ignore` files should contain `*.md` to exclude the `pre-commit/docs.md` Markdown file. The `.githooks/.ignore` file applies to each of the hook directories, and should still define filename patterns, `*.txt` instead of `**/*.txt` for example. If there is a `.ignore` file both in the hook type folder and in `.githooks`, the files whose filename matches any pattern from either of those two files will be excluded. You can also manage `.ignore` files using the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, and running `git hooks ignore <pattern>`.
 
 Hooks in individual repositories can be disabled as well, running `git hooks disable ...`, or all of them with `git hooks config set disable`, check their documentation or `help` for more information. Finally, all hook execution can be bypassed with a non-empty value in the `$GITHOOKS_DISABLE` environment variable too.
 
@@ -106,7 +130,7 @@ To try and make things a little bit more secure, Githooks checks if any new hook
 
 If the repository contains a `.githooks/trust-all` file, it is marked as a trusted repository. On the first interaction with hooks, Githooks will ask for confirmation that the user trusts all existing and future hooks in the repository, and if she does, no more confirmation prompts will be shown. This can be reverted by running either the `git config --unset githooks.trust.all`, or the `git hooks config reset trusted` command. This is a per-repository setting. These can be set up and changed with the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool as well, run `git hooks trust help` and `git hooks config help` for more information.
 
-There is a caveat worth mentioning: if a terminal *(tty)* can't be allocated, then the default action is to accept the changes or new hooks. Let me know in an issue if you strongly disagree, and you think this is a big enough risk worth having slightly worse UX instead.
+There is a caveat worth mentioning: if a terminal _(tty)_ can't be allocated, then the default action is to accept the changes or new hooks. Let me know in an issue if you strongly disagree, and you think this is a big enough risk worth having slightly worse UX instead.
 
 You can also accept changes to a hook using the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, and running `git hooks accept <hook>`. See the tool's documentation in the `docs/` folder to see the available options.
 
@@ -171,6 +195,18 @@ There is also an option to run the install script for the repository in the curr
 
 ```shell
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --single
+```
+
+Lastly, you have the option to install the templates to, and use them from a centralized location. You can read more about the difference between this option and default one [here](#Templates-vs-global-hooks). For this, run the command below.
+
+```shell
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-hookspath
+```
+
+By default the script will install the hooks into `~/.githooks/templates/`, optionally, you can also pass the path to which you want to install the centralized hooks by appending `<path>` to the command above, for example:
+
+```shell
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-hookspath /home/public/.githooks
 ```
 
 You can change this setting later with the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, running the `git hooks config [set|reset] single` command, which affects how future updates are run, when started from the local repository.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple Shell script to support per-repository [Git hooks](https://git-scm.com/
 This script can work in one of 2 ways:
 
 - Using the git template folder (default behaviour)
-- Using the git `core.hooksPath` variable (set by passing the `--use-hookspath` parameter to the install script)
+- Using the git `core.hooksPath` variable (set by passing the `--use-core-hookspath` parameter to the install script)
 
 Read about the differences between these 2 approaches below
 
@@ -202,13 +202,13 @@ You can change this setting later with the [command line helper](https://github.
 Lastly, you have the option to install the templates to, and use them from a centralized location. You can read more about the difference between this option and default one [here](#Templates-vs-global-hooks). For this, run the command below.
 
 ```shell
-$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-hookspath
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-core-hookspath
 ```
 
 By default the script will install the hooks into `~/.githooks/templates/`, optionally, you can also pass the path to which you want to install the centralized hooks by appending `<path>` to the command above, for example:
 
 ```shell
-$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-hookspath /home/public/.githooks
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-core-hookspath /home/public/.githooks
 ```
 
 It's possible to specify which template directory should be used, by passing the `--template-dir <dir>` paramter, where `<dir>` is the directory where you wish the templated be installed.

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.171303-359da1
 
 #####################################################
 # Execute the current hook,

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.171303-359da1
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -3173,7 +3173,7 @@ find_git_hook_templates() {
 
     # 2. from git config
     if [ "$USE_HOOKS_PATH" = "yes" ]; then
-        mark_directory_as_target "$(git config --global core.hooksPath)" "hooks"
+        mark_directory_as_target "$(git config --global core.hooksPath)"
     else
         mark_directory_as_target "$(git config --global init.templateDir)" "hooks"
     fi
@@ -3333,7 +3333,7 @@ setup_new_templates_folder() {
     if ! is_dry_run; then
         if mkdir -p "${TILDE_REPLACED}/hooks"; then
             # Let this one go with or without a tilde
-            set_githooks_directory "$USER_TEMPLATES"
+            set_githooks_directory "$USER_TEMPLATES/hooks"
         else
             echo "! Failed to set up the new Git templates folder"
             return
@@ -3694,7 +3694,7 @@ setup_shared_hook_repositories() {
 
 set_githooks_directory(){
     if should_use_hooksPath; then
-        mark_as_hookspath_global
+        mark_as_hookspath_global   
         git config --global core.hooksPath "$1"
         git config --global --unset init.templateDir
     else

--- a/install.sh
+++ b/install.sh
@@ -3216,7 +3216,7 @@ find_git_hook_templates() {
     printf "Do you want to set up a new Git templates folder? [y/N] "
     read -r SETUP_NEW_FOLDER
 
-    if [ "${SETUP_NEW_FOLDER}" = "y" ] || [ "${SETUP_NEW_FOLDER}" = "Y" ]; then
+    if [ "${SETUP_NEW_FOLDER}" = "y" ] || [ "${SETUP_NEW_FOLDER}" = "Y" ] || is_non_interactive; then
         setup_new_templates_folder
         if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
     fi
@@ -3696,8 +3696,10 @@ set_githooks_directory(){
     if should_use_hooksPath; then
         mark_as_hookspath_global
         git config --global core.hooksPath "$1"
+        git config --global --unset init.templateDir
     else
         git config --global init.templateDir "$1"
+        git config --global --unset core.hooksPath
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -3219,7 +3219,7 @@ find_git_hook_templates() {
     printf "Do you want to set up a new Git templates folder? [y/N] "
     read -r SETUP_NEW_FOLDER
 
-    if [ "${SETUP_NEW_FOLDER}" = "y" ] || [ "${SETUP_NEW_FOLDER}" = "Y" ] || is_non_interactive; then
+    if [ "${SETUP_NEW_FOLDER}" = "y" ] || [ "${SETUP_NEW_FOLDER}" = "Y" ]; then
         setup_new_templates_folder
         if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -2928,6 +2928,9 @@ If you find it useful, please show your support by starring the project in GitHu
 #   0 when successfully finished, 1 if failed
 ############################################################
 execute_installation() {
+    # Clear the ${TARGET_TEMPLATE_DIR} variable to allow it being passed as a parameter
+    TARGET_TEMPLATE_DIR=""
+
     parse_command_line_arguments "$@"
 
     if is_non_interactive; then
@@ -3141,7 +3144,7 @@ mark_as_hookspath_global() {
 # Prepare the target template directory variable,
 #   and make sure it points to a directory when set.
 #
-# Resets and sets the ${TARGET_TEMPLATE_DIR} variable.
+# Sets the ${TARGET_TEMPLATE_DIR} variable.
 #
 # Returns:
 #   1 if failed, 0 otherwise
@@ -3203,7 +3206,7 @@ find_git_hook_templates() {
 
             if [ "$MARK_AS_TEMPLATES" = "y" ] || [ "$MARK_AS_TEMPLATES" = "Y" ]; then
                 TEMPLATE_DIR=$(dirname "$TARGET_TEMPLATE_DIR")
-                if ! set_githooks_directory $TEMPLATE_DIR; then
+                if ! set_githooks_directory "$TEMPLATE_DIR"; then
                     echo "! Failed to set it up as Git template directory"
                 fi
             fi

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.171303-359da1
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -23,7 +23,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.171303-359da1
 
 #####################################################
 # Execute the current hook,
@@ -739,7 +739,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.171303-359da1
 
 #####################################################
 # Prints the command line help for usage and
@@ -3003,7 +3003,7 @@ parse_command_line_arguments() {
         elif [ "$prev_p" = "--template-dir" ] && (echo "$p" | grep -qvE '^\-\-.*'); then
             # Allow user to pass prefered template dir
             TARGET_TEMPLATE_DIR="$p"
-        elif [ "$p" = "--use-hookspath" ]; then
+        elif [ "$p" = "--use-core-hookspath" ]; then
             USE_HOOKS_PATH="yes"
             # No point in installing into existing when using core.hooksPath
             SKIP_INSTALL_INTO_EXISTING="yes"

--- a/tests/test-corehookspath.sh
+++ b/tests/test-corehookspath.sh
@@ -5,7 +5,7 @@ TEST_DIR=$(dirname "$0")
 cat <<EOF | docker build --force-rm -t githooks:corehookspath-base -
 FROM alpine
 RUN apk add --no-cache git curl ca-certificates
-ENV EXTRA_INSTALL_ARGS --use-hookspath
+ENV EXTRA_INSTALL_ARGS --use-core-hookspath
 EOF
 
 exec sh "$TEST_DIR"/exec-tests.sh 'corehookspath'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,11 +17,15 @@ find_git_hook_templates() {
     mark_directory_as_target "$GIT_TEMPLATE_DIR" "hooks"
     if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
 
-    # 2. from git config
+    # 2. from git config for templateDir
     mark_directory_as_target "$(git config --get init.templateDir)" "hooks"
     if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
 
-    # 3. from the default location
+    # 3. from git config for hooksPath
+    mark_directory_as_target "$(git config --get core.hooksPath)" "hooks"
+    if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
+
+    # 4. from the default location
     mark_directory_as_target "/usr/share/git-core/templates/hooks"
     if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
 }
@@ -187,6 +191,7 @@ git config --global --unset githooks.autoupdate.enabled
 git config --global --unset githooks.autoupdate.lastrun
 git config --global --unset githooks.previous.searchdir
 git config --global --unset githooks.disable
+git config --global --unset githooks.use.hookspath
 
 # Finished
 echo "All done!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -92,6 +92,10 @@ remove_existing_hook_templates() {
 #   0 on success, 1 on failure
 ############################################################
 uninstall_from_existing_repositories() {
+    # Don't offer to remove from repo's if we were using the hooksPath implementation
+    if using_hooks_path; then
+        return 0
+    fi
     printf 'Do you want to uninstall the hooks from existing repositories? [yN] '
     read -r DO_UNINSTALL
     if [ "$DO_UNINSTALL" != "y" ] && [ "$DO_UNINSTALL" != "Y" ]; then return 0; fi
@@ -166,6 +170,22 @@ uninstall_hooks_from_repo() {
     fi
 }
 
+############################################################
+# Checks if we're using the hooksPath
+#   or templateDir implementation.
+#
+# Returns:
+#   0 on true, 1 on false
+############################################################
+using_hooks_path(){
+    USE_HOOKS_PATH=`git config --global githooks.use.hookspath`
+    if [ "$USE_HOOKS_PATH" = "yes" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Find the current Git hook templates directory
 TARGET_TEMPLATE_DIR=""
 
@@ -191,7 +211,11 @@ git config --global --unset githooks.autoupdate.enabled
 git config --global --unset githooks.autoupdate.lastrun
 git config --global --unset githooks.previous.searchdir
 git config --global --unset githooks.disable
-git config --global --unset githooks.use.hookspath
+
+if using_hooks_path; then
+    git config --global --unset githooks.use.hookspath
+    git config --global --unset core.hooksPath
+fi
 
 # Finished
 echo "All done!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,7 +22,7 @@ find_git_hook_templates() {
     if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
 
     # 3. from git config for hooksPath
-    mark_directory_as_target "$(git config --get core.hooksPath)" "hooks"
+    mark_directory_as_target "$(git config --get core.hooksPath)"
     if [ "$TARGET_TEMPLATE_DIR" != "" ]; then return; fi
 
     # 4. from the default location

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -178,7 +178,7 @@ uninstall_hooks_from_repo() {
 #   0 on true, 1 on false
 ############################################################
 using_hooks_path(){
-    USE_HOOKS_PATH=`git config --global githooks.use.hookspath`
+    USE_HOOKS_PATH=$(git config --global githooks.use.hookspath)
     if [ "$USE_HOOKS_PATH" = "yes" ]; then
         return 0
     else


### PR DESCRIPTION
We noticed this project (thanks!) and wanted to use it within our organization, however to make it better suited to use in our teams, we made 2 changes:
* When running script with the `--non-interactive` parameter, the script now continues to setup a new template directory if it can't find an existing one (which is the case in most default git installations)
* The script can now be installed with `--use-hookspath` parameter, in which case the script will make the template directory the directory configured as the `core.hooksPath` parameter in the global git configuration. This allows for easier application to existing repositories, avoiding the need to search the entire disk for existing repositories.

I've updated the `README.md` for the 2nd point, to try to instruct users which mode (templateDir vs hooksPath) to use in which situation. Let me know if you approve or if you'd like to see something changed.

Thanks again for this awesome project!