### PR TITLE
Let the install script continue when --non-interactive is passed and no pre-existing template directory is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The commands below fetch and execute the [install.sh](install.sh) script from th
 4. Offer to find existing Git repositories on the filesystem (disable with `--skip-install-into-existing`)
     1. Install the hooks into them
     2. Offer to add an intro README in their `.githooks` folder
-5. Offer to set up shared hook repositories
+5.  Offer to set up shared hook repositories
 
 To install the templates, just execute the command below, and follow the instructions in the terminal.
 
@@ -161,7 +161,7 @@ If you want, you can try out what the script would do first, without changing an
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --dry-run
 ```
 
-You can also run the installation in non-interactive mode with the command below. This will try to find the template directory, install the hooks automatically, and enable periodic update checks.
+You can also run the installation in non-interactive mode with the command below. This will determine an appropriate template directory (detect and existing one, use the one passed by `--template-dir`, or use a default one), install the hooks automatically into the determined directory, and enable periodic update checks.
 
 ```shell
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --non-interactive
@@ -174,6 +174,12 @@ $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --single
 ```
 
 You can change this setting later with the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, running the `git hooks config [set|reset] single` command, which affects how future updates are run, when started from the local repository.
+
+It's possible to specify which template directory should be used, by passing the `--template-dir <dir>` paramter, where `<dir>` is the directory where you wish the templated be installed.
+
+```shell
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --template-dir /home/public/.githooks
+```
 
 Finally, if you trust GitHub URLs more, use the command below that skips the redirect from `r.viktoradam.net`. Also, some corporate proxies are not in favour of my Cloudflare certificates for some reason, so you might have a better chance with GitHub links in this case.
 

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.171015-6a0766
+# Version: 1907.110919-c0438b
 
 #####################################################
 # Execute the current hook,

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.171015-6a0766
+# Version: 1907.110919-c0438b
 
 #####################################################
 # Prints the command line help for usage and


### PR DESCRIPTION
As requested this has been separated from #19 .
I've added a custom template directory to the install script.

By passing `--template-dir` to the install script, the user can specify
which directory should be used for the teomplate directory

Also, when `--non-interactive` is passed (regardless of the above!) the script will continue with setting a new template directory if it can't find a pre-existing one, either to the directory specified by the user, or to a default directory.