### PR TITLE
Bugfix: Fail on not available shared hook.

### DIFF
--- a/.githooks/pre-commit/auto-update-inline-content
+++ b/.githooks/pre-commit/auto-update-inline-content
@@ -13,18 +13,18 @@ CLI_TOOL_PATTERN="(.+)(CLI_TOOL_CONTENT='[^']+')(.+)"
 README_PATTERN="(.+)(INCLUDED_README_CONTENT='[^']+')(.+)"
 
 if __name__ == '__main__':
-    with open('base-template.sh', 'r') as template_file:
+    with open('base-template.sh', 'r', newline="\n") as template_file:
         template_contents = template_file.read()
     
-    with open('cli.sh', 'r') as cli_tool_file:
+    with open('cli.sh', 'r', newline="\n") as cli_tool_file:
         cli_tool_contents = cli_tool_file.read()
     
-    with open('.githooks/README.md', 'r') as readme_file:
+    with open('.githooks/README.md', 'r', newline="\n") as readme_file:
         readme_contents = readme_file.read()
 
     contents = ''
 
-    with open('install.sh', 'r') as source:
+    with open('install.sh', 'r', newline="\n") as source:
         contents = source.read()
 
     match = re.match(TEMPLATE_PATTERN, contents, flags=re.MULTILINE | re.DOTALL)
@@ -48,7 +48,7 @@ if __name__ == '__main__':
         before, readme_contents, after
     )
     
-    with open('install.sh', 'w') as target:
+    with open('install.sh', 'w', newline="\n") as target:
         target.write(contents)
 EOF
 

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.181628-ac2e27
 
 #####################################################
 # Execute the current hook,
@@ -365,8 +365,22 @@ process_shared_hooks() {
     SHARED_REPOS_LIST="$1"
     shift
 
-    update_shared_hooks_if_appropriate
+    update_shared_hooks_if_appropriate "$@"
     execute_shared_hooks "$@" || return 1
+}
+
+#####################################################
+# Sets the SHARED_ROOT and NORMALIZED_NAME
+#   for the shared hook repo url `$1`.
+#
+# Returns:
+#   none
+#####################################################
+set_shared_root() {
+    NORMALIZED_NAME=$(echo "$1" |
+        sed -E "s#.*[:/](.+/.+)\\.git#\\1#" |
+        sed -E "s/[^a-zA-Z0-9]/_/g")
+    SHARED_ROOT=~/.githooks/shared/"$NORMALIZED_NAME"
 }
 
 #####################################################
@@ -378,7 +392,14 @@ process_shared_hooks() {
 #####################################################
 update_shared_hooks_if_appropriate() {
     # run an init/update if we are after a "git pull" or triggered manually
-    if [ "$HOOK_NAME" = "post-merge" ] || [ "$HOOK_NAME" = ".githooks.shared.trigger" ]; then
+    GIT_NULL_REF="0000000000000000000000000000000000000000"
+
+    RUN_UPDATE="false"
+    [ "$HOOK_NAME" = "post-merge" ] && RUN_UPDATE="true"
+    [ "$HOOK_NAME" = ".githooks.shared.trigger" ] && RUN_UPDATE="true"
+    [ "$HOOK_NAME" = "post-checkout" ] && [ "$1" = "$GIT_NULL_REF" ] && RUN_UPDATE="true"
+
+    if [ "$RUN_UPDATE" = "true" ]; then
         # split on comma and newline
         IFS=",
         "
@@ -386,13 +407,11 @@ update_shared_hooks_if_appropriate() {
         for SHARED_REPO in $SHARED_REPOS_LIST; do
             mkdir -p ~/.githooks/shared
 
-            NORMALIZED_NAME=$(echo "$SHARED_REPO" |
-                sed -E "s#.*[:/](.+/.+)\\.git#\\1#" |
-                sed -E "s/[^a-zA-Z0-9]/_/g")
+            set_shared_root "$SHARED_REPO"
 
-            if [ -d ~/.githooks/shared/"$NORMALIZED_NAME"/.git ]; then
+            if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd ~/.githooks/shared/"$NORMALIZED_NAME" && git pull 2>&1)
+                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:"
@@ -400,7 +419,8 @@ update_shared_hooks_if_appropriate() {
                 fi
             else
                 echo "* Retrieving shared hooks from: $SHARED_REPO"
-                CLONE_OUTPUT=$(cd ~/.githooks/shared && git clone "$SHARED_REPO" "$NORMALIZED_NAME" 2>&1)
+                [ -d "$SHARED_ROOT" ] && rm -rf "$SHARED_ROOT"
+                CLONE_OUTPUT=$(git clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Clone failed, git clone output:"
@@ -421,11 +441,42 @@ update_shared_hooks_if_appropriate() {
 #   1 in case a hook fails, 0 otherwise
 #####################################################
 execute_shared_hooks() {
-    for SHARED_ROOT in ~/.githooks/shared/*; do
-        REMOTE_URL=$(cd "$SHARED_ROOT" && git config --get remote.origin.url)
+    # split on comma and newline
+    IFS=",
+    "
+    for SHARED_REPO in $SHARED_REPOS_LIST; do
+
+        set_shared_root "$SHARED_REPO"
+
+        # Fail if the shared root is not available (if enabled)
+        FAIL_ON_NOT_EXISTING=$(git config --global --get githooks.failOnNotExistingSharedHooks)
+
+        if [ "$FAIL_ON_NOT_EXISTING" = "true"]; then
+            if [ ! -d "$SHARED_ROOT/.git" ]; then
+                echo "! Failed to execute shared hook: $SHARED_REPO"
+                echo "! Its is not available. Do run:"
+                echo "!   \$ git hooks shared update"
+                return 1
+            fi
+        fi
+
+        # Note: GIT_DIR might be set (?bug?) (actually the case for post-checkout hook)
+        # which means we really need a `-f` to sepcify the actual config!
+        REMOTE_URL=$(cd "$SHARED_ROOT" && git config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
-            continue
+            echo "! Failed to execute shared hook: $SHARED_REPO"
+            echo "! Shared root url \`$REMOTE_URL\` is not the same as "
+            echo "! the requested url \`$SHARED_REPO\`. Do run:"
+            echo "!   \$ git hooks shared purge"
+            echo "!   \$ git hooks shared update"
+
+            if [ "$FAIL_ON_NOT_EXISTING" = "true"]; then
+                return 1
+            else
+                echo "!   Continue..."
+                continue
+            fi
         fi
 
         if [ -d "${SHARED_ROOT}/.githooks" ]; then
@@ -433,7 +484,9 @@ execute_shared_hooks() {
         elif [ -d "$SHARED_ROOT" ]; then
             execute_all_hooks_in "$SHARED_ROOT" "$@" || return 1
         fi
+
     done
+    unset IFS
 }
 
 #####################################################

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.181628-ac2e27
+# Version: 1907.221206-176cca
 
 #####################################################
 # Execute the current hook,
@@ -449,12 +449,12 @@ execute_shared_hooks() {
         set_shared_root "$SHARED_REPO"
 
         # Fail if the shared root is not available (if enabled)
-        FAIL_ON_NOT_EXISTING=$(git config --global --get githooks.failOnNotExistingSharedHooks)
+        FAIL_ON_NOT_EXISTING=$(git config --get githooks.failOnNotExistingSharedHooks)
 
-        if [ "$FAIL_ON_NOT_EXISTING" = "true"]; then
-            if [ ! -d "$SHARED_ROOT/.git" ]; then
-                echo "! Failed to execute shared hook: $SHARED_REPO"
-                echo "! Its is not available. Do run:"
+        if [ "$FAIL_ON_NOT_EXISTING" = "true" ]; then
+            if [ ! -f "$SHARED_ROOT/.git/config" ]; then
+                echo "! Failed to execute shared hooks in $SHARED_REPO"
+                echo "! It is not available. To fix, run:"
                 echo "!   \$ git hooks shared update"
                 return 1
             fi
@@ -465,16 +465,16 @@ execute_shared_hooks() {
         REMOTE_URL=$(cd "$SHARED_ROOT" && git config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
-            echo "! Failed to execute shared hook: $SHARED_REPO"
-            echo "! Shared root url \`$REMOTE_URL\` is not the same as "
-            echo "! the requested url \`$SHARED_REPO\`. Do run:"
+            echo "! Failed to execute shared hooks in $SHARED_REPO"
+            echo "! The URL \`$REMOTE_URL\` is different."
+            echo "! To fix it, run:"
             echo "!   \$ git hooks shared purge"
             echo "!   \$ git hooks shared update"
 
-            if [ "$FAIL_ON_NOT_EXISTING" = "true"]; then
+            if [ "$FAIL_ON_NOT_EXISTING" = "true" ]; then
                 return 1
             else
-                echo "!   Continue..."
+                echo "!   Continuing..."
                 continue
             fi
         fi

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.181628-ac2e27
+# Version: 1907.221206-176cca
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1907.181628-ac2e27
+# Version: 1907.221206-176cca
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -23,7 +23,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.181628-ac2e27
+# Version: 1907.221206-176cca
 
 #####################################################
 # Execute the current hook,
@@ -468,12 +468,12 @@ execute_shared_hooks() {
         set_shared_root "$SHARED_REPO"
 
         # Fail if the shared root is not available (if enabled)
-        FAIL_ON_NOT_EXISTING=$(git config --global --get githooks.failOnNotExistingSharedHooks)
+        FAIL_ON_NOT_EXISTING=$(git config --get githooks.failOnNotExistingSharedHooks)
 
-        if [ "$FAIL_ON_NOT_EXISTING" = "true"]; then
-            if [ ! -d "$SHARED_ROOT/.git" ]; then
-                echo "! Failed to execute shared hook: $SHARED_REPO"
-                echo "! Its is not available. Do run:"
+        if [ "$FAIL_ON_NOT_EXISTING" = "true" ]; then
+            if [ ! -f "$SHARED_ROOT/.git/config" ]; then
+                echo "! Failed to execute shared hooks in $SHARED_REPO"
+                echo "! It is not available. To fix, run:"
                 echo "!   \$ git hooks shared update"
                 return 1
             fi
@@ -484,16 +484,16 @@ execute_shared_hooks() {
         REMOTE_URL=$(cd "$SHARED_ROOT" && git config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
-            echo "! Failed to execute shared hook: $SHARED_REPO"
-            echo "! Shared root url \`$REMOTE_URL\` is not the same as "
-            echo "! the requested url \`$SHARED_REPO\`. Do run:"
+            echo "! Failed to execute shared hooks in $SHARED_REPO"
+            echo "! The URL \`$REMOTE_URL\` is different."
+            echo "! To fix it, run:"
             echo "!   \$ git hooks shared purge"
             echo "!   \$ git hooks shared update"
 
-            if [ "$FAIL_ON_NOT_EXISTING" = "true"]; then
+            if [ "$FAIL_ON_NOT_EXISTING" = "true" ]; then
                 return 1
             else
-                echo "!   Continue..."
+                echo "!   Continuing..."
                 continue
             fi
         fi
@@ -792,7 +792,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.181628-ac2e27
+# Version: 1907.221206-176cca
 
 #####################################################
 # Prints the command line help for usage and

--- a/tests/step-103.sh
+++ b/tests/step-103.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Test:
+#   Fail on not available shared hooks.
+
+if ! sh /var/lib/githooks/install.sh; then
+    echo "! Failed to execute the install script"
+    exit 1
+fi
+
+mkdir -p /tmp/shared/hooks-103.git/pre-commit &&
+    echo 'exit 0' >/tmp/shared/hooks-103.git/pre-commit/succeed &&
+    cd /tmp/shared/hooks-103.git &&
+    git init &&
+    git add . &&
+    git commit -m 'Initial commit' ||
+    exit 1
+
+# Install shared hook url into a repo.
+mkdir -p /tmp/test103 && cd /tmp/test103 || exit 1
+git init || exit 1
+mkdir -p .githooks && echo '/tmp/shared/hooks-103.git' >.githooks/.shared || exit 1
+git add .githooks/.shared
+git hooks shared update
+
+RESULT=$(ls -A ~/.githooks/shared 2>/dev/null)
+if [ "$RESULT" = "" ]; then
+    echo "! Expected shared hooks to be installed."
+    exit 1
+fi
+git commit -m "Test" || exit 1
+
+# Remove all shared hooks
+git hooks shared purge || exit 1
+
+# Clone a new one
+echo "Cloning"
+cd /tmp || exit 1
+git clone /tmp/test103 test103-clone && cd test103-clone || exit 1
+
+# Remove all shared hooks
+git hooks shared purge || exit 1
+
+echo "Commiting"
+# Make a commit
+echo A >A || exit 1
+git add A || exit 1
+OUTPUT=$(git commit -a -m "Test" 2>&1)
+
+# shellcheck disable=SC2181
+if [ $? -eq 0 ] || ! echo "$OUTPUT" | grep -q "Failed to execute shared hook"; then
+    echo "! Expected to fail on not availabe shared hooks. output:"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+git hooks shared pull || exit 1
+
+# Change url
+(cd ~/.githooks/shared/shared_hooks_103* &&
+    git remote rm origin &&
+    git remote add origin /some/other/url.git) || exit 1
+# Make a commit
+echo A >>A || exit 1
+OUTPUT=$(git commit -a -m "Test" 2>&1)
+
+# shellcheck disable=SC2181
+if [ $? -eq 0 ] || ! (echo "$OUTPUT" | grep "Shared root url" | grep -q "not the same"); then
+    echo "! Expected to fail on not matching url. output:"
+    echo "$OUTPUT"
+    exit 1
+fi

--- a/tests/step-103.sh
+++ b/tests/step-103.sh
@@ -29,13 +29,21 @@ if [ "$RESULT" = "" ]; then
 fi
 git commit -m "Test" || exit 1
 
-# Remove all shared hooks
+# Remove all shared hooks and make it fail
 git hooks shared purge || exit 1
+# Fail on not existing hooks
+git config --global --add githooks.failOnNotExistingSharedHooks true || exit 1
 
 # Clone a new one
 echo "Cloning"
 cd /tmp || exit 1
 git clone /tmp/test103 test103-clone && cd test103-clone || exit 1
+
+RESULT=$(ls -A ~/.githooks/shared 2>/dev/null)
+if [ "$RESULT" = "" ]; then
+    echo "! Expected shared hooks to be installed."
+    exit 1
+fi
 
 # Remove all shared hooks
 git hooks shared purge || exit 1
@@ -55,7 +63,7 @@ fi
 
 git hooks shared pull || exit 1
 
-# Change url
+# Change url and try to make it fail
 (cd ~/.githooks/shared/shared_hooks_103* &&
     git remote rm origin &&
     git remote add origin /some/other/url.git) || exit 1
@@ -64,7 +72,7 @@ echo A >>A || exit 1
 OUTPUT=$(git commit -a -m "Test" 2>&1)
 
 # shellcheck disable=SC2181
-if [ $? -eq 0 ] || ! (echo "$OUTPUT" | grep "Shared root url" | grep -q "not the same"); then
+if [ $? -eq 0 ] || ! (echo "$OUTPUT" | grep "The URL" | grep -q "is different"); then
     echo "! Expected to fail on not matching url. output:"
     echo "$OUTPUT"
     exit 1

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -162,6 +162,36 @@ uninstall_hooks_from_repo() {
     fi
 }
 
+############################################################
+# Uninstall shared hooks.
+#
+# Returns:
+#   None
+############################################################
+uninstall_shared_hooks() {
+    if [ -d ~/.githooks/shared ]; then
+        if ! rm -rf ~/.githooks/shared >/dev/null 2>&1; then
+            echo "! Failed to delete shared hook repository folders"
+            exit 1
+        fi
+    fi
+}
+
+############################################################
+# Uninstall the cli tool.
+#
+# Returns:
+#   None
+############################################################
+uninstall_cli() {
+    if [ -d ~/.githooks/bin ]; then
+        if ! rm -rf ~/.githooks/bin >/dev/null 2>&1; then
+            echo "! Failed to delete the githook command-line tool"
+            exit 1
+        fi
+    fi
+}
+
 # Find the current Git hook templates directory
 TARGET_TEMPLATE_DIR=""
 
@@ -181,12 +211,19 @@ if ! uninstall_from_existing_repositories; then
     exit 1
 fi
 
+# Uninstall all shared hooks
+uninstall_shared_hooks
+
+# Uninstall all cli
+uninstall_cli
+
 # Unset global Githooks variables
 git config --global --unset githooks.shared
 git config --global --unset githooks.autoupdate.enabled
 git config --global --unset githooks.autoupdate.lastrun
 git config --global --unset githooks.previous.searchdir
 git config --global --unset githooks.disable
+git config --global --unset alias.hooks
 
 # Finished
 echo "All done!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -219,6 +219,7 @@ uninstall_cli
 
 # Unset global Githooks variables
 git config --global --unset githooks.shared
+git config --global --unset githooks.failOnNotExistingSharedHooks
 git config --global --unset githooks.autoupdate.enabled
 git config --global --unset githooks.autoupdate.lastrun
 git config --global --unset githooks.previous.searchdir


### PR DESCRIPTION
The `step-103.sh` should be failing. I wrote it because it does not in my setup.

-> Installing shared hooks and then accidentially removing them and making a commit should fail because the hooks are not there.

Solution: Do an update if the hooks are not there, or fail with an error "run git hooks shared update"