### PR TITLE
Dispatch User Prompts to Dialog Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,33 @@ The arguments for the download tool are:
 
 Read more about this command on the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) documentation page.
 
+### Custom User Prompt [experimental]
+If you want to use your dialog implementation, e.g. to show a GUI when githooks ask for user input.
+you can use any executable or script file to show the prompt.
+The example in the `examples/tools/dialog` folder contains a python script `run` which uses the python provided `tkinter` to show a dialog.
+
+```shell
+# install the example dialog tool from this repository
+$ git hooks tools register download "./examples/tools/dialog"
+```
+The interface of the tool is as follows.
+
+```shell
+$ run <title> <text> <options> <long-options>    # if `run` is executable
+$ sh run <title> <text> <options> <long-options> # otherwise, assuming `run` is a shell script
+```
+
+The arguments for are:
+- `<title>` the title for the user gui dialog
+- `<text>` the text for the user gui dialog
+- `<short-options>` the button return values, slash-delimited, 
+    e.g. `Y/n/d`.
+    The default button is the first capital character found.
+- `<long-options>` the button texts in the gui,
+    e.g. `Yes/no/disable`
+
+The script needs to return one of the short-options on `stdout`.
+
 ### Uninstalling
 
 If you want to get rid of these hooks and templates, you can execute the `uninstall.sh` script similarly to the install scripts.

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.181401-933c16
 
 #####################################################
 # Execute the current hook,
@@ -256,8 +256,7 @@ is_trusted_repo() {
         # shellcheck disable=SC2181
         if [ $TRUST_ALL_RESULT -ne 0 ]; then
             echo "! This repository wants you to trust all current and future hooks without prompting"
-            printf "  Do you want to allow running every current and future hooks? [y/N] "
-            read -r TRUST_ALL_HOOKS </dev/tty
+            show_prompt TRUST_ALL_HOOKS "  Do you want to allow running every current and future hooks?" "" "y/N" "Yes" "No"
 
             if [ "$TRUST_ALL_HOOKS" = "y" ] || [ "$TRUST_ALL_HOOKS" = "Y" ]; then
                 git config githooks.trust.all Y
@@ -308,8 +307,7 @@ execute_opt_in_checks() {
         if [ "$ACCEPT_CHANGES" = "a" ] || [ "$ACCEPT_CHANGES" = "A" ]; then
             echo "  Already accepted"
         else
-            printf "  Do you you accept the changes? (Yes, all, no, disable) [Y/a/n/d] "
-            read -r ACCEPT_CHANGES </dev/tty
+            show_prompt ACCEPT_CHANGES "  Do you you accept the changes?" "(Yes, all, no, disable)" "Y/a/n/d" "Yes" "All" "No" "Disable"
 
             if [ "$ACCEPT_CHANGES" = "n" ] || [ "$ACCEPT_CHANGES" = "N" ]; then
                 echo "* Not running $HOOK_FILE"
@@ -540,6 +538,48 @@ call_script() {
 }
 
 #####################################################
+# Show a prompt with the text `$2` with
+#   hint text `$3` with
+#   options `$4` in form of e.g. `Y/a/n/d` and
+#   optional long options [optional]:
+#   e.g.
+#    `$5-$8` : "Yes" "All" "None" "Disable"
+#   First capital short option character is treated
+#   as default.
+#
+#####################################################
+show_prompt() {
+    DIALOG_TOOL="$(get_tool_script "dialog")"
+    VARIABLE="$1"
+    shift
+    TEXT="$1"
+    shift
+    HINT_TEXT="$1"
+    shift
+    SHORT_OPTIONS="$1"
+    shift
+
+    if [ "$DIALOG_TOOL" != "" ]; then
+        ANSWER=$(call_script "$DIALOG_TOOL" "githook::" "$TEXT" "$SHORT_OPTIONS" "$@")
+        # shellcheck disable=SC2181
+        if [ $? -ne 0 ]; then
+            echo "! Dialog tool did not succeed -> Abort."
+            exit 1
+        fi
+        if ! echo "$SHORT_OPTIONS" | grep -q "$ANSWER"; then
+            echo "! Dialog tool did return wrong answer $ANSWER -> Abort."
+            exit 1
+        fi
+        eval "$VARIABLE"="$ANSWER"
+    else
+        # Read from stdin (because its connected)
+        # shellcheck disable=SC2059
+        printf "$TEXT $HINT_TEXT [$SHORT_OPTIONS]: "
+        read -r VARIABLE
+    fi
+}
+
+#####################################################
 # Downloads a file "$1" with `wget` or `curl`
 #
 # Returns:
@@ -659,8 +699,7 @@ is_single_repo() {
 #####################################################
 should_run_update() {
     echo "* There is a new Githooks update available: Version $LATEST_VERSION"
-    printf "    Would you like to install it now? [Y/n] "
-    read -r EXECUTE_UPDATE </dev/tty
+    show_prompt EXECUTE_UPDATE "    Would you like to install it now?" "" "Y/n" "Yes" "no"
 
     if [ -z "$EXECUTE_UPDATE" ] || [ "$EXECUTE_UPDATE" = "y" ] || [ "$EXECUTE_UPDATE" = "Y" ]; then
         return 0

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.181401-933c16
 
 #####################################################
 # Prints the command line help for usage and
@@ -1959,12 +1959,14 @@ manage_tools() {
     if [ "$1" = "help" ]; then
         print_help_header
         echo "
-git hooks tools register [download] <scriptFolder>
+git hooks tools register [download|dialog] <scriptFolder>
 
     ( experimental feature )
 
     Install the script folder \`<scriptFolder>\` in 
     the installation directory under \`tools/<toolName>\`.
+
+    Download Tool:
     The interface of the tool is as follows.
     
     # if \`run\` is executable
@@ -1972,11 +1974,30 @@ git hooks tools register [download] <scriptFolder>
     # otherwise, assuming \`run\` is a shell script
     \$ sh run <relativeFilePath> <outputFile>
     
-    The arguments for the download tool are:
+    The arguments are:
     - \`<relativeFilePath>\` is the file relative to the repository root
     - \`<outputFile>\` file to write the results to (may not exist yet)
 
-git hooks tools unregister [download]
+    Dialog Tool:
+    The interface of the tool is as follows.
+    
+    # if \`run\` is executable
+    \$ run <title> <text> <options> <long-options>
+    # otherwise, assuming \`run\` is a shell script
+    \$ sh run <title> <text> <options> <long-options>
+
+    The arguments for are:
+    - \`<title>\` the title for the user gui dialog
+    - \`<text>\` the text for the user gui dialog
+    - \`<short-options>\` the button return values, slash-delimited, 
+        e.g. \`Y/n/d\`.
+        The default button is the first capital character found.
+    - \`<long-options>\` the button texts in the gui,
+        e.g. \`Yes/no/disable\`
+
+    The script needs to return one of the short-options on \`stdout\`.
+
+git hooks tools unregister [download|dialog]
 
     ( experimental feature )
 
@@ -2012,7 +2033,7 @@ git hooks tools unregister [download]
 #   1 on failure, 0 otherwise
 #####################################################
 tools_install() {
-    if [ "$1" = "download" ]; then
+    if [ "$1" = "download" ] || [ "$1" = "dialog" ]; then
         SCRIPT_FOLDER="$2"
 
         if [ -d "$SCRIPT_FOLDER" ]; then
@@ -2041,7 +2062,7 @@ tools_install() {
             exit 1
         fi
     else
-        echo "! Invalid operation: \`$1\` (use \`download\`)"
+        echo "! Invalid operation: \`$1\` (use \`download\` or  \`dialog\`)"
         exit 1
     fi
 }
@@ -2055,7 +2076,7 @@ tools_install() {
 tools_uninstall() {
     [ "$2" = "--quiet" ] && QUIET="Y"
 
-    if [ "$1" = "download" ]; then
+    if [ "$1" = "download" ] || [ "$1" = "dialog" ]; then
         if [ -d ~/".githooks/tools/$1" ]; then
             rm -r ~/".githooks/tools/$1"
             [ -n "$QUIET" ] || echo "Uninstalled the \`$1\` tool"
@@ -2063,7 +2084,7 @@ tools_uninstall() {
             [ -n "$QUIET" ] || echo "! The \`$1\` tool is not installed"
         fi
     else
-        [ -n "$QUIET" ] || echo "! Invalid tool: \`$1\` (use \`download\`)"
+        [ -n "$QUIET" ] || echo "! Invalid tool: \`$1\` (use \`download\` or \`dailog\`)"
         exit 1
     fi
 }

--- a/docs/command-line-tool.md
+++ b/docs/command-line-tool.md
@@ -203,25 +203,44 @@ Resets the last Githooks update time with the `reset` option, causing the update
 Manages script folders for different tools. The only supported `<toolName>` is `download` tool currently.
 
 ```shell
-$ git hooks tools register [download] <scriptFolder>
+$ git hooks tools register [download|dialog] <scriptFolder>
 ```
 
 Install the script folder `<scriptFolder>` in the installation directory under `tools/<toolName>`.
 This folder need to contain a file called `run` that is either executable, or will be invoked as a shell script.
+If `run` is an executable its called as executable otherwise its assumbed to be a shell script and run by `sh run "$@"`.
+
+### Download Tool:
 The interface of the tool is as follows.
 
 ```shell
-$ run <relativeFilePath> <outputFile>     # if `run` is executable
-$ sh run <relativeFilePath> <outputFile>  # otherwise, assuming `run` is a shell script
+$ run <relativeFilePath> <outputFile>
 ```
 
-The arguments for the download tool are:
-
+The arguments are:
 - `<relativeFilePath>` is the file relative to the repository root
-- `<outputFile>` temporary file save the downloaded content to (note that this may not exist yet)
+- `<outputFile>` file to write the results to (may not exist yet)
+
+### Dialog Tool:
+The interface of the tool is as follows.
 
 ```shell
-$ git hooks tools unregister [download]
+$ run <title> <text> <options> <long-options>
+```
+
+The arguments for are:
+- `<title>` the title for the user gui dialog
+- `<text>` the text for the user gui dialog
+- `<short-options>` the button return values, slash-delimited, 
+    e.g. `Y/n/d`.
+    The default button is the first capital character found.
+- `<long-options>` the button texts in the gui,
+    e.g. `Yes/no/disable`
+
+The script needs to return one of the short-options on `stdout`.
+
+```shell
+$ git hooks tools unregister [download|dialog]
 ```
 
 Uninstall the script folder in the installation directory under `tools/<toolName>`.

--- a/examples/tools/dialog/run
+++ b/examples/tools/dialog/run
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+import platform
+import subprocess
+from tkinter import Tk
+from tkinter import dialog
+
+
+def ask(title, text, strings=('Yes', 'No'), bitmap='warning', default=0):
+    """ Making a dialog windows.
+
+    Args:
+        title (str): Title of the windows
+        text (str): Text to be show to the user
+        strings (tuple, optional): Button strings to be shown. Defaults to ('Yes', 'No').
+        bitmap (str, optional): Bitmap to use for the icon. Defaults to 'warning'.
+        default (int, optional): Index of the default button. Defaults to 0.  
+    Returns:
+        [type]: [description]
+    """
+
+    d = dialog.Dialog(title=title,
+                      text=text,
+                      bitmap=bitmap,
+                      default=default,
+                      strings=strings)
+    return d.num
+
+
+if __name__ == '__main__':
+    title = sys.argv[1]
+    text = sys.argv[2]
+    options = sys.argv[3].strip().split("/")
+
+    longOptions = []
+    if len(sys.argv) >= 5:
+        longOptions = [l.strip() for l in sys.argv[4:]]
+
+    # Fill up the long options if not given
+    if len(longOptions) < len(options):
+        longOptions += options[len(longOptions):]
+
+    default = 0
+    for idx, o in enumerate(options):
+        if o.isupper():
+            default = idx
+
+    root = Tk()
+    root.lift()
+    root.attributes('-topmost', True)
+    root.after_idle(root.attributes, '-topmost', False)
+    root.withdraw()
+
+    # Front most Hack for OS X
+    if 'Darwin' in platform.system():  # How Mac OS X is identified by Python
+        p = subprocess.Popen(
+            '''sleep 0.3 && /usr/bin/osascript -e 'tell app "Finder" to set frontmost of process "python" to true' ''',
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+
+    numButton = ask(title, text, longOptions, default=default)
+
+    print(options[numButton])

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.181401-933c16
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -23,7 +23,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.181401-933c16
 
 #####################################################
 # Execute the current hook,
@@ -275,8 +275,7 @@ is_trusted_repo() {
         # shellcheck disable=SC2181
         if [ $TRUST_ALL_RESULT -ne 0 ]; then
             echo "! This repository wants you to trust all current and future hooks without prompting"
-            printf "  Do you want to allow running every current and future hooks? [y/N] "
-            read -r TRUST_ALL_HOOKS </dev/tty
+            show_prompt TRUST_ALL_HOOKS "  Do you want to allow running every current and future hooks?" "" "y/N" "Yes" "No"
 
             if [ "$TRUST_ALL_HOOKS" = "y" ] || [ "$TRUST_ALL_HOOKS" = "Y" ]; then
                 git config githooks.trust.all Y
@@ -327,8 +326,7 @@ execute_opt_in_checks() {
         if [ "$ACCEPT_CHANGES" = "a" ] || [ "$ACCEPT_CHANGES" = "A" ]; then
             echo "  Already accepted"
         else
-            printf "  Do you you accept the changes? (Yes, all, no, disable) [Y/a/n/d] "
-            read -r ACCEPT_CHANGES </dev/tty
+            show_prompt ACCEPT_CHANGES "  Do you you accept the changes?" "(Yes, all, no, disable)" "Y/a/n/d" "Yes" "All" "No" "Disable"
 
             if [ "$ACCEPT_CHANGES" = "n" ] || [ "$ACCEPT_CHANGES" = "N" ]; then
                 echo "* Not running $HOOK_FILE"
@@ -559,6 +557,48 @@ call_script() {
 }
 
 #####################################################
+# Show a prompt with the text `$2` with
+#   hint text `$3` with
+#   options `$4` in form of e.g. `Y/a/n/d` and
+#   optional long options [optional]:
+#   e.g.
+#    `$5-$8` : "Yes" "All" "None" "Disable"
+#   First capital short option character is treated
+#   as default.
+#
+#####################################################
+show_prompt() {
+    DIALOG_TOOL="$(get_tool_script "dialog")"
+    VARIABLE="$1"
+    shift
+    TEXT="$1"
+    shift
+    HINT_TEXT="$1"
+    shift
+    SHORT_OPTIONS="$1"
+    shift
+
+    if [ "$DIALOG_TOOL" != "" ]; then
+        ANSWER=$(call_script "$DIALOG_TOOL" "githook::" "$TEXT" "$SHORT_OPTIONS" "$@")
+        # shellcheck disable=SC2181
+        if [ $? -ne 0 ]; then
+            echo "! Dialog tool did not succeed -> Abort."
+            exit 1
+        fi
+        if ! echo "$SHORT_OPTIONS" | grep -q "$ANSWER"; then
+            echo "! Dialog tool did return wrong answer $ANSWER -> Abort."
+            exit 1
+        fi
+        eval "$VARIABLE"="$ANSWER"
+    else
+        # Read from stdin (because its connected)
+        # shellcheck disable=SC2059
+        printf "$TEXT $HINT_TEXT [$SHORT_OPTIONS]: "
+        read -r VARIABLE
+    fi
+}
+
+#####################################################
 # Downloads a file "$1" with `wget` or `curl`
 #
 # Returns:
@@ -678,8 +718,7 @@ is_single_repo() {
 #####################################################
 should_run_update() {
     echo "* There is a new Githooks update available: Version $LATEST_VERSION"
-    printf "    Would you like to install it now? [Y/n] "
-    read -r EXECUTE_UPDATE </dev/tty
+    show_prompt EXECUTE_UPDATE "    Would you like to install it now?" "" "Y/n" "Yes" "no"
 
     if [ -z "$EXECUTE_UPDATE" ] || [ "$EXECUTE_UPDATE" = "y" ] || [ "$EXECUTE_UPDATE" = "Y" ]; then
         return 0
@@ -739,7 +778,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1907.110919-c0438b
+# Version: 1907.181401-933c16
 
 #####################################################
 # Prints the command line help for usage and
@@ -2687,12 +2726,14 @@ manage_tools() {
     if [ "$1" = "help" ]; then
         print_help_header
         echo "
-git hooks tools register [download] <scriptFolder>
+git hooks tools register [download|dialog] <scriptFolder>
 
     ( experimental feature )
 
     Install the script folder \`<scriptFolder>\` in 
     the installation directory under \`tools/<toolName>\`.
+
+    Download Tool:
     The interface of the tool is as follows.
     
     # if \`run\` is executable
@@ -2700,11 +2741,30 @@ git hooks tools register [download] <scriptFolder>
     # otherwise, assuming \`run\` is a shell script
     \$ sh run <relativeFilePath> <outputFile>
     
-    The arguments for the download tool are:
+    The arguments are:
     - \`<relativeFilePath>\` is the file relative to the repository root
     - \`<outputFile>\` file to write the results to (may not exist yet)
 
-git hooks tools unregister [download]
+    Dialog Tool:
+    The interface of the tool is as follows.
+    
+    # if \`run\` is executable
+    \$ run <title> <text> <options> <long-options>
+    # otherwise, assuming \`run\` is a shell script
+    \$ sh run <title> <text> <options> <long-options>
+
+    The arguments for are:
+    - \`<title>\` the title for the user gui dialog
+    - \`<text>\` the text for the user gui dialog
+    - \`<short-options>\` the button return values, slash-delimited, 
+        e.g. \`Y/n/d\`.
+        The default button is the first capital character found.
+    - \`<long-options>\` the button texts in the gui,
+        e.g. \`Yes/no/disable\`
+
+    The script needs to return one of the short-options on \`stdout\`.
+
+git hooks tools unregister [download|dialog]
 
     ( experimental feature )
 
@@ -2740,7 +2800,7 @@ git hooks tools unregister [download]
 #   1 on failure, 0 otherwise
 #####################################################
 tools_install() {
-    if [ "$1" = "download" ]; then
+    if [ "$1" = "download" ] || [ "$1" = "dialog" ]; then
         SCRIPT_FOLDER="$2"
 
         if [ -d "$SCRIPT_FOLDER" ]; then
@@ -2769,7 +2829,7 @@ tools_install() {
             exit 1
         fi
     else
-        echo "! Invalid operation: \`$1\` (use \`download\`)"
+        echo "! Invalid operation: \`$1\` (use \`download\` or  \`dialog\`)"
         exit 1
     fi
 }
@@ -2783,7 +2843,7 @@ tools_install() {
 tools_uninstall() {
     [ "$2" = "--quiet" ] && QUIET="Y"
 
-    if [ "$1" = "download" ]; then
+    if [ "$1" = "download" ] || [ "$1" = "dialog" ]; then
         if [ -d ~/".githooks/tools/$1" ]; then
             rm -r ~/".githooks/tools/$1"
             [ -n "$QUIET" ] || echo "Uninstalled the \`$1\` tool"
@@ -2791,7 +2851,7 @@ tools_uninstall() {
             [ -n "$QUIET" ] || echo "! The \`$1\` tool is not installed"
         fi
     else
-        [ -n "$QUIET" ] || echo "! Invalid tool: \`$1\` (use \`download\`)"
+        [ -n "$QUIET" ] || echo "! Invalid tool: \`$1\` (use \`download\` or \`dailog\`)"
         exit 1
     fi
 }

--- a/tests/exec-tests.sh
+++ b/tests/exec-tests.sh
@@ -14,11 +14,12 @@ ADD tests/exec-steps.sh tests/step-* /var/lib/tests/
 
 # Do not use the terminal in tests
 RUN sed -i 's|</dev/tty||g' /var/lib/githooks/install.sh && \\
+    sed -i 's|show_prompt ACCEPT_CHANGES.*|echo "Accepted: \$ACCEPT_CHANGES" # disabled for tests|' /var/lib/githooks/install.sh && \\
 # Change the base template so we can pass in the hook name and accept flags
     sed -i 's|HOOK_NAME=.*|HOOK_NAME=\${HOOK_NAME:-\$(basename "\$0")}|' /var/lib/githooks/base-template.sh && \\
     sed -i 's|HOOK_FOLDER=.*|HOOK_FOLDER=\${HOOK_FOLDER:-\$(dirname "\$0")}|' /var/lib/githooks/base-template.sh && \\
     sed -i 's|ACCEPT_CHANGES=.*|ACCEPT_CHANGES=\${ACCEPT_CHANGES}|' /var/lib/githooks/base-template.sh && \\
-    sed -i 's|read -r ACCEPT_CHANGES|echo "Accepted: \$ACCEPT_CHANGES" # disabled for tests: read -r ACCEPT_CHANGES|' /var/lib/githooks/base-template.sh
+    sed -i 's|show_prompt ACCEPT_CHANGES.*|echo "Accepted: \$ACCEPT_CHANGES" # disabled for tests|' /var/lib/githooks/base-template.sh
 
 RUN if [ -n "\${EXTRA_INSTALL_ARGS}" ]; then \\
         sed -i "s|sh /var/lib/githooks/install.sh|sh /var/lib/githooks/install.sh \${EXTRA_INSTALL_ARGS}|g" /var/lib/tests/step-* ; \\

--- a/tests/step-032.sh
+++ b/tests/step-032.sh
@@ -22,7 +22,7 @@ sed -i 's/^# Version: .*/# Version: 0/' /var/lib/githooks/base-template.sh &&
     exit 1
 
 OUTPUT=$(
-    sed -i 's|read -r EXECUTE_UPDATE </dev/tty|EXECUTE_UPDATE="N"|' /var/lib/githooks/base-template.sh &&
+    sed -i 's|show_prompt EXECUTE_UPDATE.*|EXECUTE_UPDATE="N"|' /var/lib/githooks/base-template.sh &&
         HOOK_NAME=post-commit HOOK_FOLDER=$(pwd)/.git/hooks ACCEPT_CHANGES=A \
             sh /var/lib/githooks/base-template.sh
 )

--- a/tests/step-042.sh
+++ b/tests/step-042.sh
@@ -51,7 +51,7 @@ sed -i 's/^# Version: .*/# Version: 0/' /var/lib/githooks/base-template.sh ||
     exit 1
 
 OUTPUT=$(
-    sed -i 's|read -r EXECUTE_UPDATE </dev/tty|EXECUTE_UPDATE="Y"|' /var/lib/githooks/base-template.sh &&
+    sed -i 's|show_prompt EXECUTE_UPDATE.*|EXECUTE_UPDATE="Y"|' /var/lib/githooks/base-template.sh &&
         HOOK_NAME=post-commit HOOK_FOLDER=$(pwd)/.git/hooks \
             sh /var/lib/githooks/base-template.sh
 )

--- a/tests/step-076.sh
+++ b/tests/step-076.sh
@@ -22,7 +22,7 @@ sed -i 's/^# Version: .*/# Version: 0/' /var/lib/githooks/base-template.sh &&
     exit 1
 
 OUTPUT=$(
-    sed -i 's|read -r EXECUTE_UPDATE </dev/tty|EXECUTE_UPDATE="N"|' /var/lib/githooks/base-template.sh &&
+    sed -i 's|show_prompt EXECUTE_UPDATE.*|EXECUTE_UPDATE="N"|' /var/lib/githooks/base-template.sh &&
         HOOK_NAME=post-commit HOOK_FOLDER=$(pwd)/.git/hooks ACCEPT_CHANGES=A \
             sh /var/lib/githooks/base-template.sh
 )

--- a/tests/step-077.sh
+++ b/tests/step-077.sh
@@ -23,7 +23,7 @@ sed -i 's/^# Version: .*/# Version: 0/' /var/lib/githooks/base-template.sh &&
     exit 1
 
 OUTPUT=$(
-    sed -i 's|read -r EXECUTE_UPDATE </dev/tty|EXECUTE_UPDATE="N"|' /var/lib/githooks/base-template.sh &&
+    sed -i 's|show_prompt EXECUTE_UPDATE.*|EXECUTE_UPDATE="N"|' /var/lib/githooks/base-template.sh &&
         HOOK_NAME=post-commit HOOK_FOLDER=$(pwd)/.git/hooks ACCEPT_CHANGES=A \
             sh /var/lib/githooks/base-template.sh
 )


### PR DESCRIPTION
Introduce a small tool "dialog" which dispatches all dialog prompts in `base-template.sh` to a script.
An example implementation with python3.6 and higher is given in `examples/tools/dialog`.