### PR TITLE
Bugfix: env -i is to restrictive

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.201015-bef4d7
+# Version: 1911.201542-e35c79
 
 #####################################################
 # Execute the current hook,
@@ -476,7 +476,7 @@ update_shared_hooks_if_appropriate() {
 
             if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd "$SHARED_ROOT" && env -i git pull 2>&1)
+                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git -c core.hooksPath=/dev/null --git-dir="$SHARED_ROOT/.git" pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:" >&2
@@ -485,7 +485,7 @@ update_shared_hooks_if_appropriate() {
             else
                 echo "* Retrieving shared hooks from: $SHARED_REPO"
                 [ -d "$SHARED_ROOT" ] && rm -rf "$SHARED_ROOT"
-                CLONE_OUTPUT=$(env -i git clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
+                CLONE_OUTPUT=$(git -c core.hooksPath=/dev/null clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Clone failed, git clone output:" >&2

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.201015-bef4d7
+# Version: 1911.201542-e35c79
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1911.201015-bef4d7
+# Version: 1911.201542-e35c79
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -23,7 +23,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.201015-bef4d7
+# Version: 1911.201542-e35c79
 
 #####################################################
 # Execute the current hook,
@@ -495,7 +495,7 @@ update_shared_hooks_if_appropriate() {
 
             if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd "$SHARED_ROOT" && env -i git pull 2>&1)
+                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git -c core.hooksPath=/dev/null --git-dir="$SHARED_ROOT/.git" pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:" >&2
@@ -504,7 +504,7 @@ update_shared_hooks_if_appropriate() {
             else
                 echo "* Retrieving shared hooks from: $SHARED_REPO"
                 [ -d "$SHARED_ROOT" ] && rm -rf "$SHARED_ROOT"
-                CLONE_OUTPUT=$(env -i git clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
+                CLONE_OUTPUT=$(git -c core.hooksPath=/dev/null clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Clone failed, git clone output:" >&2
@@ -912,7 +912,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.201015-bef4d7
+# Version: 1911.201542-e35c79
 
 #####################################################
 # Prints the command line help for usage and


### PR DESCRIPTION
Can we revert this. I hope this fix instead of `env -i` also passes all tests.

Also we forgot to put `-c core.hooksPath=/dev/null` as you mentioned. Which is necessary.

Why this revert: `env -i` kills everything including credentials somehow, so you need to enter passwords again etc....