### PR TITLE
Bugfix core.hooksPath

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.201542-e35c79
+# Version: 1911.212020-f03ac5
 
 #####################################################
 # Execute the current hook,

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.212020-f03ac5
+# Version: 1911.212022-20c6fe
 
 #####################################################
 # Execute the current hook,

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.201542-e35c79
+# Version: 1911.212020-f03ac5
 
 #####################################################
 # Prints the command line help for usage and

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.212020-f03ac5
+# Version: 1911.212022-20c6fe
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1911.212020-f03ac5
+# Version: 1911.212022-20c6fe
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -23,7 +23,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.212020-f03ac5
+# Version: 1911.212022-20c6fe
 
 #####################################################
 # Execute the current hook,
@@ -912,7 +912,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.212020-f03ac5
+# Version: 1911.212022-20c6fe
 
 #####################################################
 # Prints the command line help for usage and
@@ -3750,7 +3750,7 @@ search_pre_commit_sample_file() {
         read -r ACCEPT </dev/tty
 
         if [ "$ACCEPT" = "y" ] || [ "$ACCEPT" = "Y" ]; then
-            TARGET_TEMPLATE_DIR=$(dirname "$HIT")
+            TARGET_TEMPLATE_DIR="$HIT"
             return
         fi
         IFS="$IFS_NEWLINE"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -396,6 +396,15 @@ uninstall() {
     # Uninstall all cli
     uninstall_cli
 
+    if using_hooks_path; then
+        GITHOOKS_CORE_HOOKSPATH=$(git config --global githooks.pathForUseCoreHooksPath)
+        GIT_CORE_HOOKSPATH=$(git config --global core.hooksPath)
+
+        if [ "$GITHOOKS_CORE_HOOKSPATH" = "$GIT_CORE_HOOKSPATH" ]; then
+            git config --global --unset core.hooksPath
+        fi
+    fi
+
     # Unset global Githooks variables
     git config --global --unset githooks.shared
     git config --global --unset githooks.failOnNonExistingSharedHooks
@@ -404,20 +413,9 @@ uninstall() {
     git config --global --unset githooks.previous.searchdir
     git config --global --unset githooks.disable
     git config --global --unset githooks.installDir
+    git config --global --unset githooks.pathForUseCoreHooksPath
+    git config --global --unset githooks.useCoreHooksPath
     git config --global --unset alias.hooks
-
-    if using_hooks_path; then
-        git config --global --unset githooks.useCoreHooksPath
-
-        GITHOOKS_CORE_HOOKSPATH=$(git config --global githooks.pathForUseCoreHooksPath)
-        GIT_CORE_HOOKSPATH=$(git config --global core.hooksPath)
-
-        if [ "$GITHOOKS_CORE_HOOKSPATH" = "$GIT_CORE_HOOKSPATH" ]; then
-            git config --global --unset core.hooksPath
-        fi
-
-        git config --global --unset githooks.pathForUseCoreHooksPath
-    fi
 
     # Finished
     echo "All done!"


### PR DESCRIPTION
There are some really unseen errors in the changes I made. Please have look.
Its not obvious. But the path I took, now makes sense.
See the annotated comments.

Honestly, not to be unfair, but there are a lot of comments in the code base which are trivially unecessary and only make the code much harder to read:
Such things... Would be good to clean those once...
```shell
    # Delete the hook templates
    remove_existing_hook_templates "$TARGET_TEMPLATE_DIR"

    # Uninstall all shared hooks
    uninstall_shared_hooks

    # Uninstall all cli
    uninstall_cli
```
My point: If you choose your function name wisely, there is no need for a comment, which is almost the case everywhere :-)