### PR TITLE
Bugfix: core hookspath

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.260018-b70412
+# Version: 1911.252357-164a99
 
 #####################################################
 # Execute the current hook,

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.260018-b70412
+# Version: 1911.252357-164a99
 
 #####################################################
 # Prints the command line help for usage and

--- a/tests/step-115.sh
+++ b/tests/step-115.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Test:
+#   Set up bare repos, run the install and verify the hooks get installed/uninstalled
+
+if echo "$EXTRA_INSTALL_ARGS" | grep -q "use-core-hookspath"; then
+    echo "Using core.hooksPath"
+    exit 249
+fi
+
+mkdir -p /tmp/test115
+cd /tmp/test115 && git init --bare || exit 1
+
+if grep -r 'github.com/rycus86/githooks' /tmp/test115/; then
+    echo "! Hooks were installed ahead of time"
+    exit 1
+fi
+
+mkdir -p ~/.githooks/templates
+git config --global init.templateDir ~/.githooks/templates
+templateDir=$(git config --global init.templateDir)
+
+# run the install, and select installing hooks into existing repos
+echo 'n
+y
+/tmp/test115
+' | sh /var/lib/githooks/install.sh || exit 1
+
+# check if hooks are inside the template folder.
+for hook in pre-push pre-receive pre-commit; do
+    if ! [ -f "$templateDir/hooks/$hook" ]; then
+        echo "! Hooks were not installed successfully"
+        exit 1
+    fi
+done
+#shellcheck disable=2012
+count="$(ls "$templateDir/hooks/" | wc -l)"
+if [ "$count" != "19" ]; then
+    echo "! Expected only server hooks to be installed ($count)"
+    exit 1
+fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -396,6 +396,15 @@ uninstall() {
     # Uninstall all cli
     uninstall_cli
 
+    if using_hooks_path; then
+        GITHOOKS_CORE_HOOKSPATH=$(git config --global githooks.pathForUseCoreHooksPath)
+        GIT_CORE_HOOKSPATH=$(git config --global core.hooksPath)
+
+        if [ "$GITHOOKS_CORE_HOOKSPATH" = "$GIT_CORE_HOOKSPATH" ]; then
+            git config --global --unset core.hooksPath
+        fi
+    fi
+
     # Unset global Githooks variables
     git config --global --unset githooks.shared
     git config --global --unset githooks.failOnNonExistingSharedHooks
@@ -406,20 +415,9 @@ uninstall() {
     git config --global --unset githooks.disable
     git config --global --unset githooks.installDir
     git config --global --unset githooks.deleteDetectedLFSHooks
+    git config --global --unset githooks.pathForUseCoreHooksPath
+    git config --global --unset githooks.useCoreHooksPath
     git config --global --unset alias.hooks
-
-    if using_hooks_path; then
-        git config --global --unset githooks.useCoreHooksPath
-
-        GITHOOKS_CORE_HOOKSPATH=$(git config --global githooks.pathForUseCoreHooksPath)
-        GIT_CORE_HOOKSPATH=$(git config --global core.hooksPath)
-
-        if [ "$GITHOOKS_CORE_HOOKSPATH" = "$GIT_CORE_HOOKSPATH" ]; then
-            git config --global --unset core.hooksPath
-        fi
-
-        git config --global --unset githooks.pathForUseCoreHooksPath
-    fi
 
     # Finished
     echo "All done!"


### PR DESCRIPTION
The path to `--use-core-hookspath` is not parsed and set.
This is a small bug fix, with some minor cosmetics. 

- Less `ifs`, less early returns (never good to understand)
- Some errors in function `mark_directory_as_target`.
 
P.S:
Where I am not sure, but nothing to this PR. After step `# 4. Setup new folder if running` in `find_git_hook_templates` I am not sure what happens if we are there and `--use-core-hookspath`. I think its fine. Its a bit confusing... But in another way its also clear you choose a template dir and then it gets used as the core.hooksPath...