### PR TITLE
Template dir fixes :green_heart:

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,22 +193,24 @@ $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --single
 
 You can change this setting later with the [command line helper](https://github.com/rycus86/githooks/blob/master/docs/command-line-tool.md) tool, running the `git hooks config [set|reset] single` command, which affects how future updates are run, when started from the local repository.
 
+It's possible to specify which template directory should be used, by passing the `--template-dir <dir>` parameter, where `<dir>` is the directory where you wish the templates to be installed.
+
+```shell
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --template-dir /home/public/.githooks
+```
+
+By default the script will install the hooks into the `~/.githooks/templates/` directory.
+
 Lastly, you have the option to install the templates to, and use them from a centralized location. You can read more about the difference between this option and default one [below](#Templates-or-global-hooks). For this, run the command below.
 
 ```shell
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-core-hookspath
 ```
 
-By default the script will install the hooks into `~/.githooks/templates/`, optionally, you can also pass the path to which you want to install the centralized hooks by appending `<path>` to the command above, for example:
+Optionally, you can also pass the template directory to which you want to install the centralized hooks by appending `--template-dir <path>` to the command above, for example:
 
 ```shell
-$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-core-hookspath /home/public/.githooks
-```
-
-It's possible to specify which template directory should be used, by passing the `--template-dir <dir>` parameter, where `<dir>` is the directory where you wish the templates to be installed.
-
-```shell
-$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --template-dir /home/public/.githooks
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-core-hookspath --template-dir /home/public/.githooks
 ```
 
 Finally, if you trust GitHub URLs more, use the command below that skips the redirect from `r.viktoradam.net`. Also, some corporate proxies are not in favour of my Cloudflare certificates for some reason, so you might have a better chance with GitHub links in this case.
@@ -220,12 +222,14 @@ $ sh -c "$(curl -fsSL https://raw.githubusercontent.com/rycus86/githooks/master/
 The GitHub URL also accepts the additional parameters mentioned above, the `https://r.viktoradam.net/githooks` URL is just a redirect to the longer GitHub address.
 
 ### Install on the server
+
 On a server infrastructure where only *bare* repositories are maintained, it is best to maintain only server hooks.
 This can be achieved by installing with the additional flag `--only-server-hooks` by:
 
 ```shell
 $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --only-server-hooks
 ```
+
 The global template directory then **only** maintain contains the following server hooks:
 
  - `pre-push`
@@ -240,6 +244,7 @@ which get deployed with `git init` or `git clone` automatically.
 See also the [setup for bare repositories](#setup-for-bare-repositories).
 
 ### Setup for bare repositories
+
 Because bare repositories mostly live on a server, you should setup the following:
 ```shell
 cd bareRepo

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.252309-523bb9
+# Version: 1911.260018-b70412
 
 #####################################################
 # Execute the current hook,

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.252309-523bb9
+# Version: 1911.260018-b70412
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1911.252309-523bb9
+# Version: 1911.260018-b70412
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1911.252309-523bb9
+# Version: 1911.260018-b70412
 
 #####################################################
 # Execute the current hook,
@@ -917,7 +917,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1911.252309-523bb9
+# Version: 1911.260018-b70412
 
 #####################################################
 # Prints the command line help for usage and
@@ -3545,6 +3545,8 @@ parse_command_line_arguments() {
 
             INSTALL_DIR="$INSTALL_DIR/.githooks"
 
+        elif [ "$p" = "--template-dir" ]; then
+            : # nothing to do here
         elif [ "$prev_p" = "--template-dir" ] && (echo "$p" | grep -qvE '^\-\-.*'); then
             # Allow user to pass prefered template dir
             TARGET_TEMPLATE_DIR="$p"

--- a/tests/step-113.sh
+++ b/tests/step-113.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Test:
+#   Test template area is set up properly (regular)
+
+if echo "$EXTRA_INSTALL_ARGS" | grep -q "use-core-hookspath"; then
+    echo "Using core.hooksPath"
+    exit 249
+fi
+
+mkdir -p /tmp/test113/.githooks/pre-commit &&
+    echo 'echo "Testing 113" > /tmp/test113.out' >/tmp/test113/.githooks/pre-commit/test-hook &&
+    cd /tmp/test113 &&
+    git init ||
+    exit 1
+
+if grep -r 'github.com/rycus86/githooks' /tmp/test113/.git; then
+    echo "! Hooks were installed ahead of time"
+    exit 2
+fi
+
+mkdir -p ~/.githooks/templates
+
+# run the install, and select installing hooks into existing repos
+echo 'n
+y
+/tmp/test113
+' | sh /var/lib/githooks/install.sh --template-dir ~/.githooks/templates || exit 3
+
+# check if hooks are inside the template folder.
+if ! sh /var/lib/githooks/cli.sh list | grep test-hook; then
+    echo "! Hooks were not installed successfully"
+    exit 4
+fi
+
+git add . && git commit -m 'Test commit' || exit 5
+
+if ! grep 'Testing 113' /tmp/test113.out; then
+    echo "! Expected hook did not run"
+    exit 6
+fi

--- a/tests/step-114.sh
+++ b/tests/step-114.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Test:
+#   Test template area is set up properly (core.hooksPath)
+
+if echo "$EXTRA_INSTALL_ARGS" | grep -q "use-core-hookspath"; then
+    echo "Using core.hooksPath"
+    exit 249
+fi
+
+mkdir -p /tmp/test114/.githooks/pre-commit &&
+    echo 'echo "Testing 114" > /tmp/test114.out' >/tmp/test114/.githooks/pre-commit/test-hook &&
+    cd /tmp/test114 &&
+    git init ||
+    exit 1
+
+if grep -r 'github.com/rycus86/githooks' /tmp/test114/.git; then
+    echo "! Hooks were installed ahead of time"
+    exit 2
+fi
+
+mkdir -p ~/.githooks/templates
+
+# run the install, and select installing hooks into existing repos
+echo 'n
+y
+/tmp/test114
+' | sh /var/lib/githooks/install.sh --use-core-hookspath --template-dir ~/.githooks/templates || exit 3
+
+# check if hooks are inside the template folder.
+if ! sh /var/lib/githooks/cli.sh list | grep test-hook; then
+    echo "! Hooks were not installed successfully"
+    exit 4
+fi
+
+git add . && git commit -m 'Test commit' || exit 5
+
+if ! grep 'Testing 114' /tmp/test114.out; then
+    echo "! Expected hook did not run"
+    exit 6
+fi


### PR DESCRIPTION
Related to #67 

I believe this was just a documentation mistake.
We don't really want to create directories anywhere, so we get implicit consent from the user by:
- getting the path they want from `--template-dir`, and
- requiring that the target template directory exists that we've been given

This PR fixes the README, and adds two tests to show the install script invocation.