### PR TITLE
Bugfix: env -i is too restrictive. 

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1912.042217-43ad0f
+# Version: 1912.122150-8769e7
 
 #####################################################
 # Execute the current hook,
@@ -476,7 +476,7 @@ update_shared_hooks_if_appropriate() {
 
             if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git -c core.hooksPath=/dev/null --git-dir="$SHARED_ROOT/.git" pull 2>&1)
+                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:" >&2

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1912.042217-43ad0f
+# Version: 1912.122150-8769e7
 
 #####################################################
 # Prints the command line help for usage and
@@ -1261,7 +1261,7 @@ update_shared_hooks_in() {
 
         if [ -d "$SHARED_ROOT/.git" ]; then
             echo "* Updating shared hooks from: $SHARED_REPO"
-            PULL_OUTPUT="$(cd "$SHARED_ROOT" && env -i git pull 2>&1)"
+            PULL_OUTPUT="$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)"
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
                 echo "! Update failed, git pull output:" >&2
@@ -1270,7 +1270,7 @@ update_shared_hooks_in() {
         else
             echo "* Retrieving shared hooks from: $SHARED_REPO"
             [ -d "$SHARED_ROOT" ] && rm -rf "$SHARED_ROOT"
-            CLONE_OUTPUT=$(env -i git clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
+            CLONE_OUTPUT=$(git -c core.hooksPath=/dev/null clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
                 echo "! Clone failed, git clone output:" >&2

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1912.042217-43ad0f
+# Version: 1912.122150-8769e7
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1912.042217-43ad0f
+# Version: 1912.122150-8769e7
 
 #####################################################
 # Execute the current hook,
@@ -500,7 +500,7 @@ update_shared_hooks_if_appropriate() {
 
             if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git -c core.hooksPath=/dev/null --git-dir="$SHARED_ROOT/.git" pull 2>&1)
+                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:" >&2
@@ -917,7 +917,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1912.042217-43ad0f
+# Version: 1912.122150-8769e7
 
 #####################################################
 # Prints the command line help for usage and
@@ -2167,7 +2167,7 @@ update_shared_hooks_in() {
 
         if [ -d "$SHARED_ROOT/.git" ]; then
             echo "* Updating shared hooks from: $SHARED_REPO"
-            PULL_OUTPUT="$(cd "$SHARED_ROOT" && env -i git pull 2>&1)"
+            PULL_OUTPUT="$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)"
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
                 echo "! Update failed, git pull output:" >&2
@@ -2176,7 +2176,7 @@ update_shared_hooks_in() {
         else
             echo "* Retrieving shared hooks from: $SHARED_REPO"
             [ -d "$SHARED_ROOT" ] && rm -rf "$SHARED_ROOT"
-            CLONE_OUTPUT=$(env -i git clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
+            CLONE_OUTPUT=$(git -c core.hooksPath=/dev/null clone "$SHARED_REPO" "$SHARED_ROOT" 2>&1)
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
                 echo "! Clone failed, git clone output:" >&2


### PR DESCRIPTION
Can we change that? 
`git hooks shared update` fails with `env: ‘git’: No such file or directory`
on windows. The reason for this change to `env -i` was because of defined `GIT_DIR` and stuff...
I changed it to a less harsh method. I also added to ignore running any hooks.

Thanks for merging. Hopefully all tests still work with that.
