### PR TITLE
Bugfix: Execute old hooks also when disabled.

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1912.122150-8769e7
+# Version: 1912.161811-71df49
 
 #####################################################
 # Execute the current hook,
@@ -17,14 +17,15 @@ process_git_hook() {
     if are_githooks_disabled; then
         set_main_variables
         execute_lfs_hook_if_appropriate "$@" || return 1
+        execute_old_hook_if_available "$@" || return 1
         return
     fi
 
     set_main_variables
     export_staged_files
     check_for_updates_if_needed
-    execute_old_hook_if_available "$@" || return 1
     execute_lfs_hook_if_appropriate "$@" || return 1
+    execute_old_hook_if_available "$@" || return 1
     execute_global_shared_hooks "$@" || return 1
     execute_local_shared_hooks "$@" || return 1
     execute_all_hooks_in "$(pwd)/.githooks" "$@" || return 1

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1912.122150-8769e7
+# Version: 1912.161811-71df49
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 1912.122150-8769e7
+# Version: 1912.161811-71df49
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 1912.122150-8769e7
+# Version: 1912.161811-71df49
 
 #####################################################
 # Execute the current hook,
@@ -41,14 +41,15 @@ process_git_hook() {
     if are_githooks_disabled; then
         set_main_variables
         execute_lfs_hook_if_appropriate "$@" || return 1
+        execute_old_hook_if_available "$@" || return 1
         return
     fi
 
     set_main_variables
     export_staged_files
     check_for_updates_if_needed
-    execute_old_hook_if_available "$@" || return 1
     execute_lfs_hook_if_appropriate "$@" || return 1
+    execute_old_hook_if_available "$@" || return 1
     execute_global_shared_hooks "$@" || return 1
     execute_local_shared_hooks "$@" || return 1
     execute_all_hooks_in "$(pwd)/.githooks" "$@" || return 1
@@ -917,7 +918,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 1912.122150-8769e7
+# Version: 1912.161811-71df49
 
 #####################################################
 # Prints the command line help for usage and


### PR DESCRIPTION
This is a bugfix when githooks is disabled. In my opinion, the following changes should happen.