### PR TITLE
Bugfix: Finding git directories.

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2001.241152-6f44a6
+# Version: 2001.301056-ee0376
 
 #####################################################
 # Execute the current hook,

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2001.241152-6f44a6
+# Version: 2001.301056-ee0376
 
 #####################################################
 # Prints the command line help for usage and


### PR DESCRIPTION
To review. Not yet perfect.

```
GIT_DIR=$(cd "$EXISTING" && GIT_DISCOVERY_ACROSS_FILESYSTEM=0 git rev-parse --git-dir)
```
needs revisit. Return relative path??