### PR TITLE
Bugfix/fix coverage

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -526,7 +526,7 @@ update_shared_hooks_if_appropriate() {
 
             if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)
+                PULL_OUTPUT=$(git -C "$SHARED_ROOT" --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:" >&2
@@ -583,7 +583,7 @@ execute_shared_hooks() {
 
         # Note: GIT_DIR might be set (?bug?) (actually the case for post-checkout hook)
         # which means we really need a `-f` to sepcify the actual config!
-        REMOTE_URL=$(cd "$SHARED_ROOT" && git config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
+        REMOTE_URL=$(git -C "$SHARED_ROOT" config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
             echo "! Failed to execute shared hooks in $SHARED_REPO" >&2

--- a/base-template.sh
+++ b/base-template.sh
@@ -88,9 +88,9 @@ set_main_variables() {
     HOOK_FOLDER=$(dirname "$0")
     ACCEPT_CHANGES=
 
-    CURRENT_GIT_DIR=$(git rev-parse --git-common-dir)
-    if [ "${CURRENT_GIT_DIR}" = "--git-common-dir" ]; then
-        CURRENT_GIT_DIR=".git" # reset to a sensible default
+    CURRENT_GIT_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+    if [ ! -d "${CURRENT_GIT_DIR}" ]; then
+        echo "! Hook not run inside a git repository" >&2 && exit 1
     fi
 
     load_install_dir
@@ -436,13 +436,13 @@ execute_opt_in_checks() {
                 echo "  Use \`git hooks enable $HOOK_NAME $(basename "$HOOK_PATH")\` to enable it again"
                 echo "  Alternatively, edit or delete the $(pwd)/$CURRENT_GIT_DIR/.githooks.checksum file to enable it again"
 
-                echo "disabled> $HOOK_PATH" >>$CURRENT_GIT_DIR/.githooks.checksum
+                echo "disabled> $HOOK_PATH" >>"$CURRENT_GIT_DIR/.githooks.checksum"
                 return 1
             fi
         fi
 
         # save the new accepted checksum
-        echo "$MD5_HASH $HOOK_PATH" >>$CURRENT_GIT_DIR/.githooks.checksum
+        echo "$MD5_HASH $HOOK_PATH" >>"$CURRENT_GIT_DIR/.githooks.checksum"
     fi
 }
 

--- a/cli.sh
+++ b/cli.sh
@@ -148,7 +148,7 @@ find_hook_path_to_enable_or_disable() {
                 continue
             fi
 
-            REMOTE_URL=$(cd "$SHARED_ROOT" && git config --get remote.origin.url)
+            REMOTE_URL=$(git -C "$SHARED_ROOT" config --get remote.origin.url)
 
             SHARED_LOCAL_REPOS_LIST=$(grep -E "^[^#].+$" <"$(pwd)/.githooks/.shared")
             ACTIVE_LOCAL_REPO=$(echo "$SHARED_LOCAL_REPOS_LIST" | grep -o "$REMOTE_URL")
@@ -778,7 +778,7 @@ list_hooks_in_shared_repos() {
             continue
         fi
 
-        REMOTE_URL=$(cd "$SHARED_ROOT" && git config --get remote.origin.url)
+        REMOTE_URL=$(git -C "$SHARED_ROOT" config --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
             continue
@@ -1130,7 +1130,7 @@ list_shared_hook_repos() {
 
                 set_shared_root "$LIST_ITEM"
                 if [ -d "$SHARED_ROOT/.git" ]; then
-                    if [ "$(cd "$SHARED_ROOT" && git config --get remote.origin.url)" = "$LIST_ITEM" ]; then
+                    if [ "$(git -C "$SHARED_ROOT" config --get remote.origin.url)" = "$LIST_ITEM" ]; then
                         LIST_ITEM_STATE="active"
                     else
                         LIST_ITEM_STATE="invalid"
@@ -1170,7 +1170,7 @@ list_shared_hook_repos() {
                 set_shared_root "$LIST_ITEM"
 
                 if [ -d "$SHARED_ROOT/.git" ]; then
-                    if [ "$(cd "$SHARED_ROOT" && git config --get remote.origin.url)" = "$LIST_ITEM" ]; then
+                    if [ "$(git -C "$SHARED_ROOT" config --get remote.origin.url)" = "$LIST_ITEM" ]; then
                         LIST_ITEM_STATE="active"
                     else
                         LIST_ITEM_STATE="invalid"
@@ -1261,7 +1261,7 @@ update_shared_hooks_in() {
 
         if [ -d "$SHARED_ROOT/.git" ]; then
             echo "* Updating shared hooks from: $SHARED_REPO"
-            PULL_OUTPUT="$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)"
+            PULL_OUTPUT="$(git -C "$SHARED_ROOT" --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)"
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
                 echo "! Update failed, git pull output:" >&2

--- a/install.sh
+++ b/install.sh
@@ -550,7 +550,7 @@ update_shared_hooks_if_appropriate() {
 
             if [ -d "$SHARED_ROOT/.git" ]; then
                 echo "* Updating shared hooks from: $SHARED_REPO"
-                PULL_OUTPUT=$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)
+                PULL_OUTPUT=$(git -C "$SHARED_ROOT" --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)
                 # shellcheck disable=SC2181
                 if [ $? -ne 0 ]; then
                     echo "! Update failed, git pull output:" >&2
@@ -607,7 +607,7 @@ execute_shared_hooks() {
 
         # Note: GIT_DIR might be set (?bug?) (actually the case for post-checkout hook)
         # which means we really need a `-f` to sepcify the actual config!
-        REMOTE_URL=$(cd "$SHARED_ROOT" && git config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
+        REMOTE_URL=$(git -C "$SHARED_ROOT" config -f "$SHARED_ROOT/.git/config" --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
             echo "! Failed to execute shared hooks in $SHARED_REPO" >&2
@@ -1104,7 +1104,7 @@ find_hook_path_to_enable_or_disable() {
                 continue
             fi
 
-            REMOTE_URL=$(cd "$SHARED_ROOT" && git config --get remote.origin.url)
+            REMOTE_URL=$(git -C "$SHARED_ROOT" config --get remote.origin.url)
 
             SHARED_LOCAL_REPOS_LIST=$(grep -E "^[^#].+$" <"$(pwd)/.githooks/.shared")
             ACTIVE_LOCAL_REPO=$(echo "$SHARED_LOCAL_REPOS_LIST" | grep -o "$REMOTE_URL")
@@ -1734,7 +1734,7 @@ list_hooks_in_shared_repos() {
             continue
         fi
 
-        REMOTE_URL=$(cd "$SHARED_ROOT" && git config --get remote.origin.url)
+        REMOTE_URL=$(git -C "$SHARED_ROOT" config --get remote.origin.url)
         ACTIVE_REPO=$(echo "$SHARED_REPOS_LIST" | grep -o "$REMOTE_URL")
         if [ "$ACTIVE_REPO" != "$REMOTE_URL" ]; then
             continue
@@ -2086,7 +2086,7 @@ list_shared_hook_repos() {
 
                 set_shared_root "$LIST_ITEM"
                 if [ -d "$SHARED_ROOT/.git" ]; then
-                    if [ "$(cd "$SHARED_ROOT" && git config --get remote.origin.url)" = "$LIST_ITEM" ]; then
+                    if [ "$(git -C "$SHARED_ROOT" config --get remote.origin.url)" = "$LIST_ITEM" ]; then
                         LIST_ITEM_STATE="active"
                     else
                         LIST_ITEM_STATE="invalid"
@@ -2126,7 +2126,7 @@ list_shared_hook_repos() {
                 set_shared_root "$LIST_ITEM"
 
                 if [ -d "$SHARED_ROOT/.git" ]; then
-                    if [ "$(cd "$SHARED_ROOT" && git config --get remote.origin.url)" = "$LIST_ITEM" ]; then
+                    if [ "$(git -C "$SHARED_ROOT" config --get remote.origin.url)" = "$LIST_ITEM" ]; then
                         LIST_ITEM_STATE="active"
                     else
                         LIST_ITEM_STATE="invalid"
@@ -2217,7 +2217,7 @@ update_shared_hooks_in() {
 
         if [ -d "$SHARED_ROOT/.git" ]; then
             echo "* Updating shared hooks from: $SHARED_REPO"
-            PULL_OUTPUT="$(cd "$SHARED_ROOT" && git --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)"
+            PULL_OUTPUT="$(git -C "$SHARED_ROOT" --work-tree="$SHARED_ROOT" --git-dir="$SHARED_ROOT/.git" -c core.hooksPath=/dev/null pull 2>&1)"
             # shellcheck disable=SC2181
             if [ $? -ne 0 ]; then
                 echo "! Update failed, git pull output:" >&2
@@ -4305,7 +4305,7 @@ install_into_registered_repositories() {
             elif (cd "$INSTALLED_REPO" && [ "$(git config --local githooks.single.install)" = "yes" ]); then
                 # Found a registed repo which is now a single install:
                 # For safety: Remove registered flag and skip.
-                (cd "$INSTALLED_REPO" && git config --local --unset githooks.autoupdate.registered >/dev/null 2>&1)
+                git -C "$INSTALLED_REPO" config --local --unset githooks.autoupdate.registered >/dev/null 2>&1
 
             elif echo "$EXISTING_REPOSITORY_LIST" | grep -q "$INSTALLED_REPO"; then
                 # We already installed to this repository, don't install
@@ -4370,7 +4370,7 @@ install_into_registered_repositories() {
 install_hooks_into_repo() {
     TARGET="$1"
 
-    IS_BARE=$(cd "${TARGET}" && git rev-parse --is-bare-repository 2>/dev/null)
+    IS_BARE=$(git -C "${TARGET}" rev-parse --is-bare-repository 2>/dev/null)
 
     if [ ! -w "${TARGET}/hooks" ]; then
         # Try to create the .git/hooks folder
@@ -4431,7 +4431,7 @@ install_hooks_into_repo() {
     else
         # Getting the working tree (no external .git directories)
         # see https://stackoverflow.com/a/38852055/293195
-        TARGET_ROOT=$(cd "${TARGET}" && git rev-parse --show-toplevel 2>/dev/null)
+        TARGET_ROOT=$(git -C "${TARGET}" rev-parse --show-toplevel 2>/dev/null)
         if [ -z "$TARGET_ROOT" ]; then
             TARGET_ROOT=$(cd "${TARGET}" && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." && pwd)
         fi
@@ -4511,7 +4511,7 @@ register_repo_for_autoupdate() {
     echo "$CURRENT_REPO" >>"$LIST"
 
     # Mark the repo as registered.
-    (cd "$CURRENT_REPO" && git config --local githooks.autoupdate.registered "yes")
+    (git -C "$CURRENT_REPO" config --local githooks.autoupdate.registered "yes")
 
     return 0
 }

--- a/tests/exec-tests.sh
+++ b/tests/exec-tests.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 IMAGE_TYPE="$1"
+
+# Test only sepcific tests
 if [ -n "$TEST_STEP" ]; then
     STEPS_TO_RUN="step-${TEST_STEP}.sh"
 else
     STEPS_TO_RUN="step-*"
+fi
+
+# Switch to mock the download of any install.sh and use the current implementation
+if [ -n "$MOCK_DOWNLOAD" ]; then
+    echo "Execute tests by mocking the download of the install.sh script!"
 fi
 
 cat <<EOF | docker build --force-rm -t githooks:"$IMAGE_TYPE" -f - .
@@ -19,14 +26,20 @@ ADD tests/exec-steps.sh tests/${STEPS_TO_RUN} /var/lib/tests/
 
 # Do not use the terminal in tests
 RUN sed -i 's|</dev/tty||g' /var/lib/githooks/install.sh && \\
-# We overwrite the download to use the current install.sh
-    sed -i -E 's|download_file.*"install.sh"|cp -f /var/lib/githooks/install.sh|' /var/lib/githooks/install.sh && \\
 # Change the base template so we can pass in the hook name and accept flags
     sed -i -E 's|HOOK_NAME=.*|HOOK_NAME=\${HOOK_NAME:-\$(basename "\$0")}|' /var/lib/githooks/base-template.sh && \\
     sed -i -E 's|HOOK_FOLDER=.*|HOOK_FOLDER=\${HOOK_FOLDER:-\$(dirname "\$0")}|' /var/lib/githooks/base-template.sh && \\
     sed -i 's|ACCEPT_CHANGES=|ACCEPT_CHANGES=\${ACCEPT_CHANGES}|' /var/lib/githooks/base-template.sh && \\
     sed -i 's%read -r "\$VARIABLE"%eval "\$VARIABLE=\\\\\$\$(eval echo "\\\\\$VARIABLE")" # disabled for tests: read -r "\$VARIABLE"%' /var/lib/githooks/base-template.sh
-    
+
+RUN if [ -n "$MOCK_DOWNLOAD" ]; then \\
+    # We overwrite the download to use the current install.sh in all scripts
+    sed -i -E 's@(curl|wget).*(DOWNLOAD_URL|OUTPUT_FILE).*(DOWNLOAD_URL|OUTPUT_FILE).*@cp -f /var/lib/githooks/install.sh "\$OUTPUT_FILE"@g' \\
+        /var/lib/githooks/install.sh \\
+        /var/lib/githooks/cli.sh  \\
+        /var/lib/githooks/base-template.sh ; \\
+    fi
+
 RUN if [ -n "\${EXTRA_INSTALL_ARGS}" ]; then \\
         sed -i "s|sh /var/lib/githooks/install.sh|sh /var/lib/githooks/install.sh \${EXTRA_INSTALL_ARGS}|g" /var/lib/tests/step-* ; \\
         sed -i -E "s|sh -c (.*) -- |sh -c \\1 -- \${EXTRA_INSTALL_ARGS} |g" /var/lib/tests/step-* ; \\

--- a/tests/exec-tests.sh
+++ b/tests/exec-tests.sh
@@ -27,6 +27,7 @@ ADD tests/exec-steps.sh tests/${STEPS_TO_RUN} /var/lib/tests/
 # Do not use the terminal in tests
 RUN sed -i 's|</dev/tty||g' /var/lib/githooks/install.sh && \\
 # Change the base template so we can pass in the hook name and accept flags
+    sed -i -E 's|echo.*Hook not run inside a git repository.*|CURRENT_GIT_DIR=".git"|' /var/lib/githooks/base-template.sh /var/lib/githooks/install.sh && \\
     sed -i -E 's|HOOK_NAME=.*|HOOK_NAME=\${HOOK_NAME:-\$(basename "\$0")}|' /var/lib/githooks/base-template.sh && \\
     sed -i -E 's|HOOK_FOLDER=.*|HOOK_FOLDER=\${HOOK_FOLDER:-\$(dirname "\$0")}|' /var/lib/githooks/base-template.sh && \\
     sed -i 's|ACCEPT_CHANGES=|ACCEPT_CHANGES=\${ACCEPT_CHANGES}|' /var/lib/githooks/base-template.sh && \\

--- a/tests/step-116.sh
+++ b/tests/step-116.sh
@@ -3,7 +3,11 @@
 #   Test registering mechanism.
 
 # We overwrite the download to use the current install.sh !
-sed -i -E 's|download_file.*"install.sh"|cp -f /var/lib/githooks/install.sh|' /var/lib/githooks/install.sh
+# shellcheck disable=2016
+sed -i -E 's@(curl|wget).*(DOWNLOAD_URL|OUTPUT_FILE).*(DOWNLOAD_URL|OUTPUT_FILE).*@cp -f /var/lib/githooks/install.sh "\$OUTPUT_FILE"@g' \
+    /var/lib/githooks/install.sh \
+    /var/lib/githooks/cli.sh \
+    /var/lib/githooks/base-template.sh
 
 if ! sh /var/lib/githooks/install.sh; then
     echo "! Failed to execute the install script"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -215,7 +215,7 @@ uninstall_from_registered_repositories() {
             elif (cd "$INSTALLED_REPO" && [ "$(git config --local githooks.single.install)" = "yes" ]); then
                 # Found a registered repo which is now a single install:
                 # -> remove registered flag and skip.
-                (cd "$INSTALLED_REPO" && git config --local --unset githooks.autoupdate.registered >/dev/null 2>&1)
+                git -C "$INSTALLED_REPO" config --local --unset githooks.autoupdate.registered >/dev/null 2>&1
 
             else
                 # Found existing registed repository -> uninstall
@@ -356,7 +356,7 @@ uninstall_hooks_from_repo() {
 
     # If Git LFS is available, try installing the LFS hooks again
     if [ "$GIT_LFS_AVAILABLE" = "true" ]; then
-        OUTPUT=$(cd "$TARGET" && git lfs install 2>&1)
+        OUTPUT=$(git -C "$TARGET" lfs install 2>&1)
         #shellcheck disable=2181
         if [ $? -ne 0 ]; then
             echo "! Reinstalling Git LFS in \`$TARGET\` failed! Output:" >&2


### PR DESCRIPTION
Some fixes.

- [x] old git installation in kcov -> fix git command to support all version
- [x] MOCK_DOWNLOAD in tests to be able to mock all downloads for locally testing (no artefacts over the master branch). `coverage.sh` uses always the MOCK_DOWNLOAD, because its not so relevant there. For `exec-tests.sh` ist opt-in!
- [x] check kcov output, all should pass now except 116 which needs fixes.