### PR TITLE
Bugfix: No prompt if no controlling terminal could be detected :tada:

### DIFF
--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2004.162028-00b20e
+# Version: 2004.162031-c978c3
 
 #####################################################
 # Execute the current hook,
@@ -764,8 +764,8 @@ show_prompt() {
     # However, only do this when stdout *is* a tty, otherwise it is
     # likely we have no controlling terminal and reading from /dev/tty
     # would fail with an error.
+    printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
     if [ -t 0 ] && [ -t 1 ]; then
-        printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
         # shellcheck disable=SC2229
         read -r "$VARIABLE" </dev/tty
     fi

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2004.162018-62f173
+# Version: 2004.162028-00b20e
 
 #####################################################
 # Execute the current hook,
@@ -764,7 +764,7 @@ show_prompt() {
     # However, only do this when stdout *is* a tty, otherwise it is
     # likely we have no controlling terminal and reading from /dev/tty
     # would fail with an error.
-    if [ -t 1 ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
         printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
         # shellcheck disable=SC2229
         read -r "$VARIABLE" </dev/tty

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2004.162031-c978c3
+# Version: 2004.170929-8e4d56
 
 #####################################################
 # Execute the current hook,
@@ -765,13 +765,12 @@ show_prompt() {
     # likely we have no controlling terminal and reading from /dev/tty
     # would fail with an error.
     printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
-    if [ -t 0 ] && [ -t 1 ]; then
-        # shellcheck disable=SC2229
-        read -r "$VARIABLE" </dev/tty
-    fi
+    # shellcheck disable=SC2229
+    read -r "$VARIABLE" </dev/tty 2>/dev/null
 
-    # By default: If we end up here we do not modify the variable
-    # and gracefully do nothing, leaving the decision to the caller.
+    # If the above gives any error (e.g. /dev/tty could not be written to or read from),
+    # ${$VARIABLE} is not changed
+    # and we leave the decision to the caller.
 }
 
 #####################################################

--- a/base-template.sh
+++ b/base-template.sh
@@ -4,7 +4,7 @@
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2003.110904-cb74d9
+# Version: 2004.162018-62f173
 
 #####################################################
 # Execute the current hook,
@@ -759,15 +759,19 @@ show_prompt() {
     fi
 
     # Try to read from `dev/tty` if available.
-    # otherwise just read from stdin.
-    printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
-    if [ -t 0 ]; then
+    # Our stdin is never a tty (either a pipe or /dev/null when called
+    # from git), so read from /dev/tty, our controlling terminal.
+    # However, only do this when stdout *is* a tty, otherwise it is
+    # likely we have no controlling terminal and reading from /dev/tty
+    # would fail with an error.
+    if [ -t 1 ]; then
+        printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
         # shellcheck disable=SC2229
         read -r "$VARIABLE" </dev/tty
-    else
-        # shellcheck disable=SC2229
-        read -r "$VARIABLE"
     fi
+
+    # By default: If we end up here we do not modify the variable
+    # and gracefully do nothing, leaving the decision to the caller.
 }
 
 #####################################################

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2004.162031-c978c3
+# Version: 2004.170929-8e4d56
 
 #####################################################
 # Prints the command line help for usage and

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2004.162028-00b20e
+# Version: 2004.162031-c978c3
 
 #####################################################
 # Prints the command line help for usage and

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2003.110904-cb74d9
+# Version: 2004.162018-62f173
 
 #####################################################
 # Prints the command line help for usage and

--- a/cli.sh
+++ b/cli.sh
@@ -11,7 +11,7 @@
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2004.162018-62f173
+# Version: 2004.162028-00b20e
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 2004.162028-00b20e
+# Version: 2004.162031-c978c3
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2004.162028-00b20e
+# Version: 2004.162031-c978c3
 
 #####################################################
 # Execute the current hook,
@@ -788,8 +788,8 @@ show_prompt() {
     # However, only do this when stdout *is* a tty, otherwise it is
     # likely we have no controlling terminal and reading from /dev/tty
     # would fail with an error.
+    printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
     if [ -t 0 ] && [ -t 1 ]; then
-        printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
         # shellcheck disable=SC2229
         read -r "$VARIABLE" </dev/tty
     fi
@@ -977,7 +977,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2004.162028-00b20e
+# Version: 2004.162031-c978c3
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 2004.162031-c978c3
+# Version: 2004.170929-8e4d56
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2004.162031-c978c3
+# Version: 2004.170929-8e4d56
 
 #####################################################
 # Execute the current hook,
@@ -789,13 +789,12 @@ show_prompt() {
     # likely we have no controlling terminal and reading from /dev/tty
     # would fail with an error.
     printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
-    if [ -t 0 ] && [ -t 1 ]; then
-        # shellcheck disable=SC2229
-        read -r "$VARIABLE" </dev/tty
-    fi
+    # shellcheck disable=SC2229
+    read -r "$VARIABLE" </dev/tty 2>/dev/null
 
-    # By default: If we end up here we do not modify the variable
-    # and gracefully do nothing, leaving the decision to the caller.
+    # If the above gives any error (e.g. /dev/tty could not be written to or read from),
+    # ${$VARIABLE} is not changed
+    # and we leave the decision to the caller.
 }
 
 #####################################################
@@ -977,7 +976,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2004.162031-c978c3
+# Version: 2004.170929-8e4d56
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 2003.110904-cb74d9
+# Version: 2004.162018-62f173
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2003.110904-cb74d9
+# Version: 2004.162018-62f173
 
 #####################################################
 # Execute the current hook,
@@ -783,15 +783,19 @@ show_prompt() {
     fi
 
     # Try to read from `dev/tty` if available.
-    # otherwise just read from stdin.
-    printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
-    if [ -t 0 ]; then
+    # Our stdin is never a tty (either a pipe or /dev/null when called
+    # from git), so read from /dev/tty, our controlling terminal.
+    # However, only do this when stdout *is* a tty, otherwise it is
+    # likely we have no controlling terminal and reading from /dev/tty
+    # would fail with an error.
+    if [ -t 1 ]; then
+        printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
         # shellcheck disable=SC2229
         read -r "$VARIABLE" </dev/tty
-    else
-        # shellcheck disable=SC2229
-        read -r "$VARIABLE"
     fi
+
+    # By default: If we end up here we do not modify the variable
+    # and gracefully do nothing, leaving the decision to the caller.
 }
 
 #####################################################
@@ -973,7 +977,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2003.110904-cb74d9
+# Version: 2004.162018-62f173
 
 #####################################################
 # Prints the command line help for usage and

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #   and performs some optional setup for existing repositories.
 #   See the documentation in the project README for more information.
 #
-# Version: 2004.162018-62f173
+# Version: 2004.162028-00b20e
 
 # The list of hooks we can manage with this script
 MANAGED_HOOK_NAMES="
@@ -28,7 +28,7 @@ BASE_TEMPLATE_CONTENT='#!/bin/sh
 # It allows you to have a .githooks folder per-project that contains
 # its hooks to execute on various Git triggers.
 #
-# Version: 2004.162018-62f173
+# Version: 2004.162028-00b20e
 
 #####################################################
 # Execute the current hook,
@@ -788,7 +788,7 @@ show_prompt() {
     # However, only do this when stdout *is* a tty, otherwise it is
     # likely we have no controlling terminal and reading from /dev/tty
     # would fail with an error.
-    if [ -t 1 ]; then
+    if [ -t 0 ] && [ -t 1 ]; then
         printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
         # shellcheck disable=SC2229
         read -r "$VARIABLE" </dev/tty
@@ -977,7 +977,7 @@ CLI_TOOL_CONTENT='#!/bin/sh
 # See the documentation in the project README for more information,
 #   or run the `git hooks help` command for available options.
 #
-# Version: 2004.162018-62f173
+# Version: 2004.162028-00b20e
 
 #####################################################
 # Prints the command line help for usage and


### PR DESCRIPTION
By https://github.com/rycus86/githooks/pull/81#issuecomment-614782632
this fix should fix the logic when we read from /dev/tty for getting an answer to a prompt.
We dont modify the variable read into if we could not read something from a controlling terminal:

@matthijskooijman Shouldn't we only (if and only if) read from /dev/tty when stdin is also a tty meaning the change should be maybe even more strict: 
```shell
if [-t 0] && [ -t 1 ]; then
        printf "%s %s [%s]:" "$TEXT" "$HINT_TEXT" "$SHORT_OPTIONS"
        # shellcheck disable=SC2229
        read -r "$VARIABLE" </dev/tty
    fi
```