### PR TITLE
Bugfix/fail in fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ $ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --use-core-hookspat
 If you want to install from another repository (e.g. from your own fork), you can specify the update repository url as well as the branch name (default: `master`) when installing with:
 
 ```shell
-$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --update-clone-url "https://server.com/my-githooks-fork.git" --update-clone-branch "release"
+$ sh -c "$(curl -fsSL https://r.viktoradam.net/githooks)" -- --clone-url "https://server.com/my-githooks-fork.git" --clone-branch "release"
 ```
 
 This will be then used for installation and further updates.

--- a/base-template.sh
+++ b/base-template.sh
@@ -803,6 +803,25 @@ fetch_latest_updates() {
     # We do a fresh clone if there is not repository
     if is_git_repo "$GITHOOKS_CLONE_DIR"; then
 
+        URL=$(execute_git "$GITHOOKS_CLONE_DIR" config remote.origin.url 2>/dev/null)
+        BRANCH=$(execute_git "$GITHOOKS_CLONE_DIR" symbolic-ref -q --short HEAD 2>/dev/null)
+
+        if [ "$URL" != "$GITHOOKS_CLONE_URL" ] ||
+            [ "$BRANCH" != "$GITHOOKS_CLONE_BRANCH" ]; then
+            echo "! Cannot fetch updates because \`origin\` of update clone" >&2
+            echo "  \`$GITHOOKS_CLONE_DIR\`" >&2
+            echo "  points to url:" >&2
+            echo "  \`$URL\`" >&2
+            echo "  on branch \`$BRANCH\`" >&2
+            echo "  which is not configured." >&2
+            echo "  See \`git hooks config [set|print] update-clone-url\` and" >&2
+            echo "      \`git hooks config [set|print] update-clone-branch\`" >&2
+            echo "  Either fix this or delete the clone" >&2
+            echo "  \`$GITHOOKS_CLONE_DIR\`" >&2
+            echo "  to trigger a new checkout." >&2
+            return 1
+        fi
+
         FETCH_OUTPUT=$(
             execute_git "$GITHOOKS_CLONE_DIR" fetch origin "$GITHOOKS_CLONE_BRANCH" 2>&1
         )

--- a/base-template.sh
+++ b/base-template.sh
@@ -814,8 +814,8 @@ fetch_latest_updates() {
             echo "  \`$URL\`" >&2
             echo "  on branch \`$BRANCH\`" >&2
             echo "  which is not configured." >&2
-            echo "  See \`git hooks config [set|print] update-clone-url\` and" >&2
-            echo "      \`git hooks config [set|print] update-clone-branch\`" >&2
+            echo "  See \`git hooks config [set|print] clone-url\` and" >&2
+            echo "      \`git hooks config [set|print] clone-branch\`" >&2
             echo "  Either fix this or delete the clone" >&2
             echo "  \`$GITHOOKS_CLONE_DIR\`" >&2
             echo "  to trigger a new checkout." >&2

--- a/cli.sh
+++ b/cli.sh
@@ -1951,14 +1951,14 @@ git hooks config [enable|disable|reset|print] update
     The \`reset\` option clears this setting.
     The \`print\` option outputs the current setting.
 
-git hooks config set update-clone-url <git-url>
-git hooks config [set|print] update-clone-url
+git hooks config set clone-url <git-url>
+git hooks config [set|print] clone-url
 
     Sets or prints the configured githooks clone url used
     for any update.
 
-git hooks config set update-clone-branch <branch-name>
-git hooks config print update-clone-branch
+git hooks config set clone-branch <branch-name>
+git hooks config print clone-branch
 
     Sets or prints the configured branch of the update clone
     used for any update.
@@ -2027,10 +2027,10 @@ The \`print\` option outputs the current behavior.
     "update")
         config_update_state "$CONFIG_OPERATION" "$@"
         ;;
-    "update-clone-url")
+    "clone-url")
         config_update_clone_url "$CONFIG_OPERATION" "$@"
         ;;
-    "update-clone-branch")
+    "clone-branch")
         config_update_clone_branch "$CONFIG_OPERATION" "$@"
         ;;
     "update-time")

--- a/docs/command-line-tool.md
+++ b/docs/command-line-tool.md
@@ -208,15 +208,15 @@ $ git hooks config [reset|print] update-time
 Resets the last Githooks update time with the `reset` option, causing the update check to run next time if it is enabled. Use `git hooks update [enable|disable]` to change that setting. The `print` option outputs the current value of it.
 
 ```shell
-git hooks config set update-clone-url <git-url>
-git hooks config [set|print] update-clone-url
+git hooks config set clone-url <git-url>
+git hooks config [set|print] clone-url
 ```
 
 Sets or prints the configured githooks clone url used for any update.
 
 ```shell
-git hooks config set update-clone-branch <branch-name>
-git hooks config print update-clone-branch
+git hooks config set clone-branch <branch-name>
+git hooks config print clone-branch
 ```
 
 Sets or prints the configured branch of the update clone used for any update.

--- a/install.sh
+++ b/install.sh
@@ -278,13 +278,13 @@ parse_command_line_arguments() {
             USE_CORE_HOOKSPATH="true"
             # No point in installing into existing when using core.hooksPath
             SKIP_INSTALL_INTO_EXISTING="true"
-        elif [ "$p" = "--update-clone-url" ]; then
+        elif [ "$p" = "--clone-url" ]; then
             : # nothing to do here
-        elif [ "$prev_p" = "--update-clone-url" ] && (echo "$p" | grep -qvE '^\-\-.*'); then
+        elif [ "$prev_p" = "--clone-url" ] && (echo "$p" | grep -qvE '^\-\-.*'); then
             GITHOOKS_CLONE_URL="$p"
-        elif [ "$p" = "--update-clone-branch" ]; then
+        elif [ "$p" = "--clone-branch" ]; then
             : # nothing to do here
-        elif [ "$prev_p" = "--update-clone-branch" ] && (echo "$p" | grep -qvE '^\-\-.*'); then
+        elif [ "$prev_p" = "--clone-branch" ] && (echo "$p" | grep -qvE '^\-\-.*'); then
             GITHOOKS_CLONE_BRANCH="$p"
         else
             echo "! Unknown argument \`$p\`" >&2
@@ -1470,8 +1470,8 @@ update_release_clone() {
                 echo "  \`$URL\`" >&2
                 echo "  on branch \`$BRANCH\`" >&2
                 echo "  which is not configured." >&2
-                echo "  See \`git hooks config [set|print] update-clone-url\` and" >&2
-                echo "      \`git hooks config [set|print] update-clone-branch\`" >&2
+                echo "  See \`git hooks config [set|print] clone-url\` and" >&2
+                echo "      \`git hooks config [set|print] clone-branch\`" >&2
                 echo "  Either fix this or delete the clone" >&2
                 echo "  \`$GITHOOKS_CLONE_DIR\`" >&2
                 echo "  to trigger a new checkout." >&2


### PR DESCRIPTION
- Add a fail message if url/branch is not correct during fetch. This is needed, we already do this in install as well but the fetch can also fail stupidly if we do not check before if everything is correct as we want it. Its not mission critical but gives bad output
- Rename wrong cli.sh command `update-clone-branch` and `update-clone-url` to reflect the 

Thanks for merging.