### PR TITLE
Added global setting to trigger shared update by custom hook names

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Supported entries for shared hooks are:
   because it makes little sense and is a security risk.
 
 Shared hooks repositories specified by *URLs* and *local paths to bare repository* will be checked out into the `<install-prefix>/.githooks/shared` folder (`~/.githooks/shared` by default), and are updated automatically after a `post-merge` event (typically a `git pull`) on any local repositories. Any other local path will be used **directly and will not be updated or modified**.
+Additionally, the update can also be triggered on other hook names by setting a comma-separated list of additional hook names in the Git configuration parameter `githooks.sharedHooksUpdateTriggers` on any configuration level.
 
 The layout of these shared repositories is the same as above, with the exception that the hook folders (or files) can be at the project root as well, to avoid the redundant `.githooks` folder.
 

--- a/base-template.sh
+++ b/base-template.sh
@@ -582,8 +582,10 @@ update_shared_hooks_if_appropriate() {
     GIT_NULL_REF="0000000000000000000000000000000000000000"
 
     RUN_UPDATE="false"
+
     [ "$HOOK_NAME" = "post-merge" ] && RUN_UPDATE="true"
     [ "$HOOK_NAME" = "post-checkout" ] && [ "$1" = "$GIT_NULL_REF" ] && RUN_UPDATE="true"
+    git config --get-all githooks.sharedHooksUpdateTriggers | grep -q "$HOOK_NAME" && RUN_UPDATE="true"
 
     if [ "$RUN_UPDATE" = "true" ]; then
 

--- a/install.sh
+++ b/install.sh
@@ -1590,8 +1590,7 @@ register_repo() {
 }
 
 ############################################################
-# Optionally setup shared hook repositories locally
-#   with their related Git config variables.
+# Optionally setup global shared hook repositories.
 #
 # Returns:
 #   None
@@ -1644,8 +1643,13 @@ setup_shared_hook_repositories() {
     elif [ "$PROVIDED" = "true" ]; then
         # Trigger the shared hook repository checkout manually
         sh "$GITHOOKS_CLONE_DIR/cli.sh" shared update --global
-        echo "Shared hook repositories have been set up. You can change them any time by running this script again, or manually by changing the 'githooks.shared' Git config variable."
-        echo "Note: you can also list the shared hook repos per project within the .githooks/.shared file"
+
+        echo "Shared hook repositories have been set up."
+        echo "You can change them any time by running this script"
+        echo "again, or manually by changing the 'githooks.shared'"
+        echo "Git config variable."
+        echo "Note: you can also list the shared hook repos per"
+        echo "project within the .githooks/.shared file"
     else
         echo "! Failed to set up the shared hook repositories" >&2
         git config --global --unset-all githooks.shared >/dev/null 2>&1

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -343,8 +343,9 @@ uninstall_hooks_from_repo() {
         cd "${TARGET}" &&
             git config --local --unset githooks.single.install >/dev/null &&             # legacy setting (deperecated)
             git config --local --unset githooks.autoupdate.registered >/dev/null 2>&1 && # legacy settings (deprecated)
-            git config --local --unset githooks.install.registered >/dev/null 2>&1
-        git config --local --unset-all githooks.shared >/dev/null 2>&1
+            git config --local --unset githooks.install.registered >/dev/null 2>&1 &&
+            git config --local --unset-all githooks.shared >/dev/null 2>&1 &&
+            git config --local --unset-all githooks.sharedHooksUpdateTriggers >/dev/null 2>&1
     )
 
     if [ "$UNINSTALLED" = "true" ]; then
@@ -618,6 +619,7 @@ uninstall() {
     git config --global --unset githooks.deleteDetectedLFSHooks
     git config --global --unset githooks.pathForUseCoreHooksPath
     git config --global --unset githooks.useCoreHooksPath
+    git config --global --unset-all githooks.sharedHooksUpdateTriggers
     git config --global --unset alias.hooks
 
     # Legacy


### PR DESCRIPTION
This is a PR to trigger shared hooks update by a global or local `githooks.sharedHooksUpdateTriggers` setting, which is a comma separated list (does not matter we just grep for the name) of hook names which all trigger the shared hook update additional to `post-merge` and `post-checkout 00000...`

This is related to #123 

@rycus86 : What do you think?

- [x]  Needs documentation
- ~[ ] Maybe needs a cli implementation (I think its not so important)~
