### PR TITLE
Bugfix: Pass zero ref to --internal-updated-from on clone

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1806,6 +1806,7 @@ update_release_clone() {
     if [ "$CREATE_NEW_CLONE" = "true" ]; then
 
         clone_release_repository || return 1
+        GITHOOKS_CLONE_UPDATED_FROM_COMMIT="0000000000000000000000000000000000000000"
         GITHOOKS_CLONE_CREATED="true"
         GITHOOKS_CLONE_UPDATED="true"
 


### PR DESCRIPTION
Thanks for merging.

We should pass a null ref to `--internal-updated-from` such that we know we have newly cloned the release clone.
Might come handy in the future.

Furthermore related to this problem and a bit trickier:
- I installed with a local path as the clone url -> `/data/git/repositories/githooks.git`  (on a gitea server)
- This results in a stupid `legacy_transform_after_update` because `--depth 1` is not honoured for local paths (git stuff)  and the  `if [ "$COMMIT_COUNT" != "1" ]` passes... :bomb: 
This fix resolves this problem!