### PR TITLE
Bugfix: Always setting the internal update flag is wanted

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1760,9 +1760,10 @@ execute_git() {
 #   - `GITHOOKS_CLONE_UPDATED` (also for clone)
 #   - `GITHOOKS_CLONE_UPDATED_FROM_COMMIT`
 #
-#   `GITHOOKS_CLONE_UPDATED_FROM_COMMIT` is empty if no update happened
-#   or the Git null ref "000..000" if a new cloned happened or
-#   the commit sha from where was updated.
+#   `GITHOOKS_CLONE_UPDATED_FROM_COMMIT` is empty if
+#    no update happened or the Git null ref
+#    "000..000" if a new cloned happened or
+#   the commit SHA from where was updated.
 #
 # Returns:
 #   1 if failed, 0 otherwise

--- a/install.sh
+++ b/install.sh
@@ -1759,6 +1759,11 @@ execute_git() {
 #   - `GITHOOKS_CLONE_CREATED`
 #   - `GITHOOKS_CLONE_UPDATED` (also for clone)
 #   - `GITHOOKS_CLONE_UPDATED_FROM_COMMIT`
+#
+#   `GITHOOKS_CLONE_UPDATED_FROM_COMMIT` is empty if no update happened
+#   or the Git null ref "000..000" if a new cloned happened or
+#   the commit sha from where was updated.
+#
 # Returns:
 #   1 if failed, 0 otherwise
 #####################################################
@@ -1970,12 +1975,11 @@ run_internal_install() {
         return 1
     fi
 
-    ADD_ARGS=""
-    [ -n "$GITHOOKS_CLONE_UPDATED_FROM_COMMIT" ] &&
-        ADD_ARGS="--internal-updated-from $GITHOOKS_CLONE_UPDATED_FROM_COMMIT"
-
     # shellcheck disable=SC2086
-    sh "$INSTALL_SCRIPT" $ADD_ARGS --internal-install "$@" || return 1
+    sh "$INSTALL_SCRIPT" $ADD_ARGS \
+        --internal-install \
+        --internal-updated-from "$GITHOOKS_CLONE_UPDATED_FROM_COMMIT" \
+        "$@" || return 1
 }
 
 ############################################################


### PR DESCRIPTION
- it has three destinct meanings:
  - sha -> update commit from
  - null sha -> new clone happened
  - empty -> no update happened, still on the same sha

This is needed for the legacy check `[ -z "$INTERNAL_UPDATED_FROM_COMMIT" ]` in
legacy_transform_after_update,
which should only opt-in from old installs.

We forgot to make `--internal-update-from` bomb proof: This should hopefully fix
this.