### PR TITLE
Also set clone url after fetch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1892,6 +1892,11 @@ update_release_clone() {
                 return 1
             fi
 
+            # Ensure we have clone url and branch set (technically not necessary)
+            # its possible to have them not set till now...
+            git config --global githooks.cloneUrl "$GITHOOKS_CLONE_URL"
+            git config --global githooks.cloneBranch "$GITHOOKS_CLONE_BRANCH"
+
             # shellcheck disable=SC2034
             GITHOOKS_CLONE_UPDATED_FROM_COMMIT="$CURRENT_COMMIT"
             GITHOOKS_CLONE_UPDATED="true"


### PR DESCRIPTION
Small fix because of either odd situation (just gracefully fixing this)

```
install.sh --clone-url "$url" \
        --clone-branch "$branch"
```
and an allraedy installed githooks with release clone the same as "$url" and "$branch" but deleted configs `githooks.cloneUrl` etc...
