### PR TITLE
Make script more deterministic by clearing `CDPATH`

### DIFF
--- a/.githooks/pre-commit/no-set-x
+++ b/.githooks/pre-commit/no-set-x
@@ -1,5 +1,5 @@
 #!/bin/sh
-DIR=$(cd "$(dirname "$0")" && pwd)
+DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 . "$DIR/.export-staged"
 
 assertStaged

--- a/.githooks/pre-commit/no-tabs
+++ b/.githooks/pre-commit/no-tabs
@@ -1,5 +1,5 @@
 #!/bin/sh
-DIR=$(cd "$(dirname "$0")" && pwd)
+DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 . "$DIR/.export-staged"
 
 assertStaged

--- a/.githooks/pre-commit/no-todo-or-fixme
+++ b/.githooks/pre-commit/no-todo-or-fixme
@@ -1,5 +1,5 @@
 #!/bin/sh
-DIR=$(cd "$(dirname "$0")" && pwd)
+DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 . "$DIR/.export-staged"
 
 assertStaged

--- a/.githooks/pre-commit/shellcheck
+++ b/.githooks/pre-commit/shellcheck
@@ -1,5 +1,5 @@
 #!/bin/sh
-DIR=$(cd "$(dirname "$0")" && pwd)
+DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 . "$DIR/.export-staged"
 
 assertStaged

--- a/.githooks/pre-commit/shellcheck-ignore-format
+++ b/.githooks/pre-commit/shellcheck-ignore-format
@@ -1,5 +1,5 @@
 #!/bin/sh
-DIR=$(cd "$(dirname "$0")" && pwd)
+DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 . "$DIR/.export-staged"
 
 assertStaged

--- a/.githooks/pre-commit/shfmt
+++ b/.githooks/pre-commit/shfmt
@@ -1,5 +1,5 @@
 #!/bin/sh
-DIR=$(cd "$(dirname "$0")" && pwd)
+DIR=$(CDPATH='' cd "$(dirname "$0")" && pwd)
 . "$DIR/.export-staged"
 
 assertStaged

--- a/base-template.sh
+++ b/base-template.sh
@@ -109,6 +109,9 @@ set_main_variables() {
     IFS_NEWLINE="
 "
 
+    # Ensure user-customized CDPATHs do not change behavior
+    unset -v CDPATH
+
     # Fail if the shared root is not available (if enabled)
     FAIL_ON_NOT_EXISTING_SHARED_HOOK=$(git config --get githooks.failOnNonExistingSharedHooks)
 

--- a/cli.sh
+++ b/cli.sh
@@ -96,6 +96,9 @@ set_main_variables() {
     # Global IFS for loops
     IFS_NEWLINE="
 "
+
+    # Ensure user-customized CDPATHs do not change behavior
+    unset -v CDPATH
 }
 
 #####################################################

--- a/hooks/applypatch-msg
+++ b/hooks/applypatch-msg
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-applypatch
+++ b/hooks/post-applypatch
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-index-change
+++ b/hooks/post-index-change
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-receive
+++ b/hooks/post-receive
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-rewrite
+++ b/hooks/post-rewrite
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/post-update
+++ b/hooks/post-update
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-applypatch
+++ b/hooks/pre-applypatch
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-auto-gc
+++ b/hooks/pre-auto-gc
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-merge-commit
+++ b/hooks/pre-merge-commit
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-rebase
+++ b/hooks/pre-rebase
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/pre-receive
+++ b/hooks/pre-receive
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/push-to-checkout
+++ b/hooks/push-to-checkout
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/reference-transaction
+++ b/hooks/reference-transaction
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/sendemail-validate
+++ b/hooks/sendemail-validate
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/hooks/update
+++ b/hooks/update
@@ -7,7 +7,7 @@
 # This file is auto-generated, do not edit!
 
 # Read the runner script from the local/global or system config
-GITHOOKS_RUNNER="$(cd "$(dirname "$0")/../" && pwd)/base-template.sh"
+GITHOOKS_RUNNER="$(CDPATH='' cd "$(dirname "$0")/../" && pwd)/base-template.sh"
 
 if [ ! -x "$GITHOOKS_RUNNER" ]; then
     echo "! Githooks runner points to a non existing location" >&2

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,10 @@ execute_installation() {
     # Global IFS for loops
     IFS_NEWLINE="
 "
+
+    # Ensure user-customized CDPATHs do not change behavior
+    unset -v CDPATH
+
     parse_command_line_arguments "$@" || return 1
 
     load_install_dir || return 1

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -511,9 +511,13 @@ parse_command_line_args() {
 # Returns: None
 #####################################################
 set_main_variables() {
-
+    # Global IFS for loops
     IFS_NEWLINE="
 "
+
+    # Ensure user-customized CDPATHs do not change behavior
+    unset -v CDPATH
+
     load_install_dir || return 1
 
     # do we have Git LFS installed


### PR DESCRIPTION
As mentioned in [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cd.html), the _environment variable_ `CDPATH` chagnes the behavior of `cd`. Notably, it can cause the directory to be changed to an unexpected location. This makes the script less [deterministic](https://reproducible-builds.org/docs/deterministic-build-systems/).

My changeset causes `CDPATH` to be taken account by either unsetting it, or setting it to an empty string.